### PR TITLE
refresh planner customer issue corpus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Recent history uses short, imperative-style messages, occasionally with a PR num
 - A clear description of the skill or change.
 - Rationale and prerequisites (when adding a new component).
 - Steps to use or verify the change.
+- When referencing TiDB issues or pull requests, use the full GitHub URL (for example, `https://github.com/pingcap/tidb/issues/67498`) instead of bare `#12345` references to avoid cross-repo ambiguity.
 
 ## Security & Configuration Tips
 Do not commit secrets in skills or references. If a skill requires credentials, document environment variable names in `SKILL.md` and provide placeholders only.

--- a/skills/tidb-query-tuning/AGENTS.md
+++ b/skills/tidb-query-tuning/AGENTS.md
@@ -12,7 +12,7 @@ Use GitHub issue mining when:
 - the local references do not cover a customer-facing symptom well enough
 - you need a recent field precedent instead of a general tuning rule
 - you want fix PRs, merge timestamps, and open issue reminders
-- you want to build or refresh a local corpus of customer-driven planner or stats bugs
+- you want to build or refresh a local corpus of planner or stats bugs, with `report/customer` issues preferred when they exist
 
 Do not start from issue mining if a stable reference under `references/` already answers the question. Use the issue corpus to complement the topic docs, not replace them.
 
@@ -21,8 +21,9 @@ Do not start from issue mining if a stable reference under `references/` already
 1. Start with the local references in `references/`.
 2. Search `references/optimizer-oncall-experiences-redacted/` for a symptom match.
 3. Search `references/tidb-customer-planner-issues/` if you need linked PRs, merge times, or still-open customer gaps.
-4. If the local corpora are still missing the pattern, mine GitHub issues with the script in `scripts/`.
-5. Review the generated files, then fold reusable learnings back into the relevant reference docs when appropriate.
+4. If the most relevant recent planner issue does not carry `report/customer`, do not exclude it for that reason alone. Broaden the GitHub query and inspect it directly.
+5. If the local corpora are still missing the pattern, mine GitHub issues with the script in `scripts/`.
+6. Review the generated files, then fold reusable learnings back into the relevant reference docs when appropriate.
 
 ## Issue mining script
 
@@ -44,19 +45,25 @@ The current checked-in issue corpus lives under:
 
 ## Recommended query patterns
 
-For customer-driven planner issues:
+Preferred query for customer-driven planner issues:
 
 ```text
 repo:pingcap/tidb is:issue label:"report/customer" label:"sig/planner" created:>=2024-01-01
 ```
 
-For stats-heavy issue mining:
+Fallback query for recent planner issues when `report/customer` is missing but the issue is still highly relevant:
+
+```text
+repo:pingcap/tidb is:issue label:"sig/planner" created:>=2024-01-01
+```
+
+Preferred query for stats-heavy issue mining:
 
 ```text
 repo:pingcap/tidb is:issue label:"report/customer" (label:"sig/planner" OR label:"sig/execution") stats created:>=2024-01-01
 ```
 
-Adjust the query rather than hardcoding different behaviors into the script.
+Adjust the query rather than hardcoding different behaviors into the script. `report/customer` is a prioritization signal, not a hard requirement.
 
 ## Usage example
 

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
@@ -1,30 +1,41 @@
 # TiDB Customer Planner Issues
 
+- Repository: `pingcap/tidb`
 - Source Query: `repo:pingcap/tidb is:issue label:"report/customer" label:"sig/planner" created:>=2024-01-01`
-- Total Issues: 175
+- Total Issues: 186
 
 | Issue | Status | Type | Linked PR Count | File |
 | --- | --- | --- | ---: | --- |
-| #66668 | open | type/enhancement | 1 | [issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md](./issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md) |
+| #67468 | open | type/enhancement | 0 | [issue-67468-support-join-reorder-for-semi-join.md](./issue-67468-support-join-reorder-for-semi-join.md) |
+| #67467 | open | type/enhancement | 0 | [issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md](./issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md) |
+| #67409 | open | type/enhancement | 0 | [issue-67409-planner-white-list-based-plan-cache-strategy.md](./issue-67409-planner-white-list-based-plan-cache-strategy.md) |
+| #67385 | open | type/bug | 0 | [issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md](./issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md) |
+| #67366 | open | type/enhancement | 3 | [issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md](./issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md) |
+| #67363 | open | type/enhancement | 0 | [issue-67363-planner-better-binding-matching-mechanism.md](./issue-67363-planner-better-binding-matching-mechanism.md) |
+| #67138 | closed | type/bug | 2 | [issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md](./issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md) |
+| #66919 | open | type/enhancement | 2 | [issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md](./issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md) |
+| #66903 | closed | type/bug | 1 | [issue-66903-planner-task-nil-pointer.md](./issue-66903-planner-task-nil-pointer.md) |
+| #66668 | closed | type/enhancement | 2 | [issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md](./issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md) |
 | #66658 | open | type/enhancement | 0 | [issue-66658-planner-decrease-concurrency-batch-size-automatically-for-streaming-plans-with-l.md](./issue-66658-planner-decrease-concurrency-batch-size-automatically-for-streaming-plans-with-l.md) |
 | #66623 | closed | type/bug | 3 | [issue-66623-planner-same-plans-with-different-in-list-should-have-the-same-plan-digests.md](./issue-66623-planner-same-plans-with-different-in-list-should-have-the-same-plan-digests.md) |
 | #66320 | open | type/bug | 1 | [issue-66320-planner-correlate-a-non-correlated-in-subquery.md](./issue-66320-planner-correlate-a-non-correlated-in-subquery.md) |
 | #66203 | open | type/enhancement | 0 | [issue-66203-planner-decrease-the-default-value-64mb-of-tidb-opt-range-max-size.md](./issue-66203-planner-decrease-the-default-value-64mb-of-tidb-opt-range-max-size.md) |
+| #65938 | closed | type/bug | 2 | [issue-65938-can-t-find-column-column-6-in-schema-column-column-5-pkoruk-nullableuk.md](./issue-65938-can-t-find-column-column-6-in-schema-column-column-5-pkoruk-nullableuk.md) |
 | #65924 | open | type/bug | 2 | [issue-65924-the-estrows-of-equal-condition-is-overestimated-when-the-modify-count-is-zero.md](./issue-65924-the-estrows-of-equal-condition-is-overestimated-when-the-modify-count-is-zero.md) |
 | #65916 | open | type/bug | 0 | [issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md](./issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md) |
 | #65915 | closed | type/bug | 1 | [issue-65915-analyze-statement-freezes-if-saveanalyzeresulttostorage-meets-error-when-analyze.md](./issue-65915-analyze-statement-freezes-if-saveanalyzeresulttostorage-meets-error-when-analyze.md) |
 | #65878 | open | type/enhancement | 1 | [issue-65878-planner-plan-cache-support-queries-with-int-col-str-val.md](./issue-65878-planner-plan-cache-support-queries-with-int-col-str-val.md) |
 | #65876 | closed | type/enhancement | 1 | [issue-65876-planner-non-prep-plan-cache-support-is-null.md](./issue-65876-planner-non-prep-plan-cache-support-is-null.md) |
-| #65867 | closed | type/bug | 1 | [issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md](./issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md) |
+| #65867 | closed | type/bug | 2 | [issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md](./issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md) |
 | #65838 | open | type/bug | 0 | [issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md](./issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md) |
 | #65822 | open | type/enhancement | 0 | [issue-65822-support-building-indexmerge-path-and-pushing-down-limit-for-in-expression-in-nes.md](./issue-65822-support-building-indexmerge-path-and-pushing-down-limit-for-in-expression-in-nes.md) |
-| #65818 | open | type/bug | 1 | [issue-65818-analyze-cannot-be-cancelled-promptly.md](./issue-65818-analyze-cannot-be-cancelled-promptly.md) |
+| #65818 | closed | type/bug | 1 | [issue-65818-analyze-cannot-be-cancelled-promptly.md](./issue-65818-analyze-cannot-be-cancelled-promptly.md) |
 | #65712 | open | type/enhancement | 1 | [issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md](./issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md) |
 | #65639 | open | type/bug | 0 | [issue-65639-sql-binding-fails-silently-when-sql-is-too-long-binding-created-but-not-visible-.md](./issue-65639-sql-binding-fails-silently-when-sql-is-too-long-binding-created-but-not-visible-.md) |
-| #65556 | open | type/bug | 1 | [issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md](./issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md) |
+| #65556 | open | type/bug | 2 | [issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md](./issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md) |
 | #65489 | closed | type/bug | 3 | [issue-65489-memory-leak-when-analyze-table-is-the-last-statement-in-a-session.md](./issue-65489-memory-leak-when-analyze-table-is-the-last-statement-in-a-session.md) |
 | #65381 | closed | type/bug | 3 | [issue-65381-planner-the-optimizer-can-t-use-the-latest-tidb-mem-quota-binding-cache-value-to.md](./issue-65381-planner-the-optimizer-can-t-use-the-latest-tidb-mem-quota-binding-cache-value-to.md) |
-| #65208 | open | type/enhancement | 1 | [issue-65208-support-using-ordering-property-to-get-better-join-order.md](./issue-65208-support-using-ordering-property-to-get-better-join-order.md) |
+| #65208 | open | type/enhancement | 2 | [issue-65208-support-using-ordering-property-to-get-better-join-order.md](./issue-65208-support-using-ordering-property-to-get-better-join-order.md) |
 | #65183 | closed | type/bug | 2 | [issue-65183-planner-row-count-incorrectly-forced-to-1-for-indexjoin-when-matching-only-a-pre.md](./issue-65183-planner-row-count-incorrectly-forced-to-1-for-indexjoin-when-matching-only-a-pre.md) |
 | #65166 | closed | type/bug | 4 | [issue-65166-planner-outer-join-cannot-be-eliminated-due-to-the-impact-of-the-expression-inde.md](./issue-65166-planner-outer-join-cannot-be-eliminated-due-to-the-impact-of-the-expression-inde.md) |
 | #65165 | closed | type/enhancement | 1 | [issue-65165-planner-outer-join-should-be-eliminated-when-join-keys-do-not-use-nulleq-and-can.md](./issue-65165-planner-outer-join-should-be-eliminated-when-join-keys-do-not-use-nulleq-and-can.md) |
@@ -38,7 +49,7 @@
 | #64648 | open | type/enhancement | 0 | [issue-64648-planner-optimizer-uses-total-table-size-for-partition-table-scan-cost-estimation.md](./issue-64648-planner-optimizer-uses-total-table-size-for-partition-table-scan-cost-estimation.md) |
 | #64643 | closed | type/bug | 3 | [issue-64643-planner-read-from-storage-hint-table-alias-matching-problem-when-using-crossdb-b.md](./issue-64643-planner-read-from-storage-hint-table-alias-matching-problem-when-using-crossdb-b.md) |
 | #64572 | closed | type/bug | 3 | [issue-64572-planner-unexpected-low-out-of-range-estimation-on-index-stats.md](./issue-64572-planner-unexpected-low-out-of-range-estimation-on-index-stats.md) |
-| #64463 | open | type/bug | 0 | [issue-64463-tidb-report-error-some-columns-of-limit-69-cannot-find-the-reference-from-its-ch.md](./issue-64463-tidb-report-error-some-columns-of-limit-69-cannot-find-the-reference-from-its-ch.md) |
+| #64463 | closed | type/bug | 0 | [issue-64463-tidb-report-error-some-columns-of-limit-69-cannot-find-the-reference-from-its-ch.md](./issue-64463-tidb-report-error-some-columns-of-limit-69-cannot-find-the-reference-from-its-ch.md) |
 | #64423 | closed | type/bug | 3 | [issue-64423-analyze-a-small-table-costs-a-lot-of-memory.md](./issue-64423-analyze-a-small-table-costs-a-lot-of-memory.md) |
 | #64375 | closed | type/enhancement | 2 | [issue-64375-planner-a-more-fine-grained-track-of-optimization-time.md](./issue-64375-planner-a-more-fine-grained-track-of-optimization-time.md) |
 | #64345 | open | type/enhancement | 0 | [issue-64345-recommend-index-statements-may-be-slow-and-can-t-be-killed.md](./issue-64345-recommend-index-statements-may-be-slow-and-can-t-be-killed.md) |
@@ -109,9 +120,10 @@
 | #59986 | closed | type/enhancement | 1 | [issue-59986-planner-support-long-binding-statement.md](./issue-59986-planner-support-long-binding-statement.md) |
 | #59972 | closed | type/enhancement | 3 | [issue-59972-planner-selection-splits-the-join-group-to-two-parts-forbidding-join-reorder-to-.md](./issue-59972-planner-selection-splits-the-join-group-to-two-parts-forbidding-join-reorder-to-.md) |
 | #59902 | closed | type/bug | 2 | [issue-59902-the-estrows-is-wrong-for-inner-operator-of-index-join.md](./issue-59902-the-estrows-is-wrong-for-inner-operator-of-index-join.md) |
+| #59876 | closed | type/bug | 1 | [issue-59876-covering-indexes-do-not-work-in-update-joins.md](./issue-59876-covering-indexes-do-not-work-in-update-joins.md) |
 | #59869 | open | type/enhancement | 0 | [issue-59869-unionall-should-be-able-to-reserve-the-order-property-comming-from-its-children.md](./issue-59869-unionall-should-be-able-to-reserve-the-order-property-comming-from-its-children.md) |
 | #59759 | closed | type/bug | 7 | [issue-59759-data-too-long-field-len-x-error-when-loading-stats-for-a-bit-column.md](./issue-59759-data-too-long-field-len-x-error-when-loading-stats-for-a-bit-column.md) |
-| #59652 | open | type/enhancement | 3 | [issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md](./issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md) |
+| #59652 | open | type/enhancement | 4 | [issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md](./issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md) |
 | #59560 | closed | type/bug | 7 | [issue-59560-memory-leak-risk-in-session-pool-usage-in-stats-sync-load.md](./issue-59560-memory-leak-risk-in-session-pool-usage-in-stats-sync-load.md) |
 | #59524 | closed | type/bug | 8 | [issue-59524-release-the-internal-session-which-may-meet-error-like-54022.md](./issue-59524-release-the-internal-session-which-may-meet-error-like-54022.md) |
 | #59427 | closed | type/bug | 3 | [issue-59427-comments-style-optimizer-hints-can-t-work-for-point-get-plan-sometimes.md](./issue-59427-comments-style-optimizer-hints-can-t-work-for-point-get-plan-sometimes.md) |

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
@@ -1,13 +1,14 @@
-# TiDB Customer Planner Issues
+# TiDB Customer Issue Experiences
 
 - Repository: `pingcap/tidb`
 - Source Query: `repo:pingcap/tidb is:issue label:"report/customer" label:"sig/planner" created:>=2024-01-01`
-- Total Issues: 186
+- Total Issues: 187
 
 | Issue | Status | Type | Linked PR Count | File |
 | --- | --- | --- | ---: | --- |
+| #67498 | open | type/bug | 1 | [issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md](./issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md) |
 | #67468 | open | type/enhancement | 0 | [issue-67468-support-join-reorder-for-semi-join.md](./issue-67468-support-join-reorder-for-semi-join.md) |
-| #67467 | open | type/enhancement | 0 | [issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md](./issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md) |
+| #67467 | open | type/enhancement | 1 | [issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md](./issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md) |
 | #67409 | open | type/enhancement | 0 | [issue-67409-planner-white-list-based-plan-cache-strategy.md](./issue-67409-planner-white-list-based-plan-cache-strategy.md) |
 | #67385 | open | type/bug | 0 | [issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md](./issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md) |
 | #67366 | open | type/enhancement | 3 | [issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md](./issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md) |

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
@@ -2,7 +2,7 @@
 
 - Repository: `pingcap/tidb`
 - Source Query: `repo:pingcap/tidb is:issue label:"report/customer" label:"sig/planner" created:>=2024-01-01`
-- Total Issues: 187
+- Total Issues: 188
 
 | Issue | Status | Type | Linked PR Count | File |
 | --- | --- | --- | ---: | --- |
@@ -14,6 +14,7 @@
 | #67366 | open | type/enhancement | 3 | [issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md](./issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md) |
 | #67363 | open | type/enhancement | 0 | [issue-67363-planner-better-binding-matching-mechanism.md](./issue-67363-planner-better-binding-matching-mechanism.md) |
 | #67138 | closed | type/bug | 2 | [issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md](./issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md) |
+| #67108 | closed | type/enhancement | 1 | [issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md](./issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md) |
 | #66919 | open | type/enhancement | 2 | [issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md](./issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md) |
 | #66903 | closed | type/bug | 1 | [issue-66903-planner-task-nil-pointer.md](./issue-66903-planner-task-nil-pointer.md) |
 | #66668 | closed | type/enhancement | 2 | [issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md](./issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md) |

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md
@@ -79,6 +79,34 @@
   - tests/integrationtest/r/planner/core/casetest/rule/rule_result_reorder.result
   - tests/integrationtest/r/util/ranger.result
   PR Summary: What problem does this PR solve? Problem Summary: This is a an enhancement for the planner range derivation logic for IN list which produces more ranges than the equivalent OR predicate. See example below. The ranges [1,1] [2,2] for the IN predicate compared to [1,2] for the equivalent OR predicate. Both forms scan the same data but less ranges could perform better especially if the number of ranges is high.  This issue addresses of on the potential side effect of issue  that aims to produce one canonical form for IN and irs equivalent OR list. What changed and how does it work?
+- Fix PR #67125: planner: merge OR and IN predicates into IN lists | tidb-test=pr/2714
+  URL: https://github.com/pingcap/tidb/pull/67125
+  State: open
+  Merged At: not merged
+  Changed Files Count: 31
+  Main Modules: pkg/planner/core, tests/integrationtest, pkg/executor
+  Sample Changed Files:
+  - pkg/executor/explainfor_test.go
+  - pkg/planner/core/casetest/indexmerge/BUILD.bazel
+  - pkg/planner/core/casetest/indexmerge/indexmerge_path_test.go
+  - pkg/planner/core/casetest/indexmerge/testdata/index_merge_suite_out.json
+  - pkg/planner/core/casetest/indexmerge/testdata/index_merge_suite_xut.json
+  - pkg/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
+  - pkg/planner/core/casetest/partition/testdata/integration_partition_suite_xut.json
+  - pkg/planner/core/casetest/partition/testdata/partition_pruner_out.json
+  - pkg/planner/core/casetest/partition/testdata/partition_pruner_xut.json
+  - pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+  - pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_xut.json
+  - pkg/planner/core/casetest/plancache/plan_cache_partition_table_test.go
+  - pkg/planner/core/casetest/rule/testdata/predicate_simplification_in.json
+  - pkg/planner/core/casetest/rule/testdata/predicate_simplification_out.json
+  - pkg/planner/core/casetest/rule/testdata/predicate_simplification_xut.json
+  - pkg/planner/core/casetest/testdata/integration_suite_out.json
+  - pkg/planner/core/casetest/testdata/integration_suite_xut.json
+  - pkg/planner/core/casetest/tpcds/testdata/tpcds_suite_out.json
+  - pkg/planner/core/casetest/tpcds/testdata/tpcds_suite_xut.json
+  - pkg/planner/core/indexmerge_path.go
+  PR Summary: What problem does this PR solve? Problem Summary: Predicate simplification can already remove duplicated branches from , but it does not collapse same-column equality disjunctions into a single  list. This misses a straightforward simplification for predicates like: The previous implementation in #63162 handles a broader  rewrite, but that approach is more general and more invasive than what is needed here. What changed and how does it work?
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-59652-rewrite-exprs-like-a-10-or-a-20-or-a-30-to-a-in-10-20-30-for-better-expr-evaluat.md
@@ -83,12 +83,10 @@
   URL: https://github.com/pingcap/tidb/pull/67125
   State: open
   Merged At: not merged
-  Changed Files Count: 31
+  Changed Files Count: 27
   Main Modules: pkg/planner/core, tests/integrationtest, pkg/executor
   Sample Changed Files:
   - pkg/executor/explainfor_test.go
-  - pkg/planner/core/casetest/indexmerge/BUILD.bazel
-  - pkg/planner/core/casetest/indexmerge/indexmerge_path_test.go
   - pkg/planner/core/casetest/indexmerge/testdata/index_merge_suite_out.json
   - pkg/planner/core/casetest/indexmerge/testdata/index_merge_suite_xut.json
   - pkg/planner/core/casetest/partition/testdata/integration_partition_suite_out.json
@@ -105,8 +103,10 @@
   - pkg/planner/core/casetest/testdata/integration_suite_xut.json
   - pkg/planner/core/casetest/tpcds/testdata/tpcds_suite_out.json
   - pkg/planner/core/casetest/tpcds/testdata/tpcds_suite_xut.json
-  - pkg/planner/core/indexmerge_path.go
-  PR Summary: What problem does this PR solve? Problem Summary: Predicate simplification can already remove duplicated branches from , but it does not collapse same-column equality disjunctions into a single  list. This misses a straightforward simplification for predicates like: The previous implementation in #63162 handles a broader  rewrite, but that approach is more general and more invasive than what is needed here. What changed and how does it work?
+  - pkg/planner/core/rule/rule_predicate_simplification.go
+  - pkg/planner/core/testdata/plan_suite_unexported_out.json
+  - tests/integrationtest/r/executor/partition/partition_boundaries.result
+  PR Summary: What problem does this PR solve? Problem Summary: Predicate simplification can already remove duplicated branches from expressions such as , but it still keeps many same-column disjunctions in non-normalized forms, for example: This means logically equivalent predicates may reach later optimization stages in different shapes, which makes plan output and related test expectations less consistent than they need to be. What changed and how does it work?
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-59876-covering-indexes-do-not-work-in-update-joins.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-59876-covering-indexes-do-not-work-in-update-joins.md
@@ -1,0 +1,30 @@
+# Issue #59876: Covering indexes do not work in update joins
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/59876
+- Status: closed
+- Type: type/bug
+- Created At: 2025-03-03T13:02:43Z
+- Closed At: 2026-03-19T09:45:30Z
+- Labels: report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- 1. Minimal reproduce step (Required)
+
+## Linked PRs
+- Fix PR #66845: planner: keep covering indexes for read-only tables in update join | tidb-test=pr/2706 
+  URL: https://github.com/pingcap/tidb/pull/66845
+  State: closed
+  Merged At: 2026-03-19T09:45:30Z
+  Changed Files Count: 5
+  Main Modules: pkg/planner/core, pkg/planner, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/issuetest/planner_issue_test.go
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/core/operator/physicalop/physical_common_plans.go
+  - pkg/planner/util/handle_cols.go
+  - tests/integrationtest/r/bindinfo/bind.result
+  PR Summary: What problem does this PR solve? Problem Summary: freezes the join output before optimization and disables projection elimination for the update sub-plan. Before this change, the frozen projection kept the full mixed row for every joined table, including read-only source tables. That polluted the required column set with extra writable columns and row handles, so a covering index on the read-only side could not stay as . What changed and how does it work? identify which joined tables are actually updated after
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-61716-avoid-indexmerge-double-read-for-multi-valued-index.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-61716-avoid-indexmerge-double-read-for-multi-valued-index.md
@@ -29,8 +29,8 @@
   PR Summary: What problem does this PR solve? Problem Summary: executor,planner: add index-only index-merge path for MVIndex queries What changed and how does it work? Summary Add an index-only fast path for  when accessing MVIndex in eligible queries.
 - Fix PR #66996: planner: enable index-only MV IndexMerge only for single covered partial path (optimizer part)
   URL: https://github.com/pingcap/tidb/pull/66996
-  State: open
-  Merged At: not merged
+  State: closed
+  Merged At: 2026-03-18T11:28:33Z
   Changed Files Count: 7
   Main Modules: pkg/planner/core, pkg/executor
   Sample Changed Files:

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-63235-with-the-introduction-of-issaferange-cpu-resources-are-consumed-more-heavily.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-63235-with-the-introduction-of-issaferange-cpu-resources-are-consumed-more-heavily.md
@@ -123,19 +123,28 @@
   - pkg/planner/core/find_best_task.go
   - pkg/planner/core/stats.go
   PR Summary: This is an automated cherry-pick of #66304 What problem does this PR solve? Problem Summary: What changed and how does it work? This PR provides 2 main optimizations:
-- Related PR #66695: planner: optimize for full range (#66304)
+- Related PR #66695: planner: optimize for full range (#66304) | tidb-test=pr/2708
   URL: https://github.com/pingcap/tidb/pull/66695
   State: open
   Merged At: not merged
-  Changed Files Count: 6
-  Main Modules: pkg/planner, pkg/planner/core, .cursor/commands
+  Changed Files Count: 15
+  Main Modules: pkg/planner/core, pkg/planner, tests/integrationtest, pkg/ddl, pkg/executor
   Sample Changed Files:
-  - .cursor/commands/new-question.md
+  - pkg/ddl/tests/partition/db_partition_test.go
+  - pkg/executor/test/analyzetest/analyze_test.go
+  - pkg/planner/cardinality/BUILD.bazel
   - pkg/planner/cardinality/row_count_index.go
   - pkg/planner/cardinality/selectivity_test.go
+  - pkg/planner/core/casetest/physicalplantest/testdata/plan_suite_out.json
+  - pkg/planner/core/casetest/planstats/testdata/plan_stats_suite_out.json
   - pkg/planner/core/find_best_task.go
+  - pkg/planner/core/logical_plans_test.go
   - pkg/planner/core/stats.go
+  - pkg/planner/core/testdata/index_merge_suite_out.json
   - pkg/planner/util/path.go
+  - tests/integrationtest/r/imdbload.result
+  - tests/integrationtest/r/planner/core/casetest/index/index.result
+  - tests/integrationtest/r/planner/core/plan_cost_ver2.result
   PR Summary: This is an automated cherry-pick of #66304 What problem does this PR solve? Problem Summary: What changed and how does it work? This PR provides 2 main optimizations:
 
 ## Notes

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-64463-tidb-report-error-some-columns-of-limit-69-cannot-find-the-reference-from-its-ch.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-64463-tidb-report-error-some-columns-of-limit-69-cannot-find-the-reference-from-its-ch.md
@@ -2,9 +2,10 @@
 
 ## Metadata
 - Issue: https://github.com/pingcap/tidb/issues/64463
-- Status: open
+- Status: closed
 - Type: type/bug
 - Created At: 2025-11-13T08:34:47Z
+- Closed At: 2026-04-01T05:49:24Z
 - Labels: affects-7.5, report/customer, sig/planner, type/bug
 
 ## Customer-Facing Phenomenon
@@ -14,4 +15,4 @@
 - No linked PR was found from the issue timeline.
 
 ## Notes
-- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.
+- The issue is closed, but no merged PR was resolved automatically from the timeline. It may have been fixed by an internal branch, a batch PR, or manual closure.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65059-tiflash-plan-returns-no-access-path-error-in-rc-isolation-level.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65059-tiflash-plan-returns-no-access-path-error-in-rc-isolation-level.md
@@ -33,22 +33,16 @@
   PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work? Because we use RC isolation, so  is true. Here will not remove the tikv path.
 - Fix PR #66951: planner: fix no access path when TiKV read is disabled under RC isolation (#65127)
   URL: https://github.com/pingcap/tidb/pull/66951
-  State: open
-  Merged At: not merged
-  Changed Files Count: 11
-  Main Modules: pkg/planner/core, pkg/planner, tests/integrationtest
+  State: closed
+  Merged At: 2026-03-17T19:37:48Z
+  Changed Files Count: 5
+  Main Modules: pkg/planner/core, Makefile
   Sample Changed Files:
+  - Makefile
   - pkg/planner/core/casetest/enforcempp/BUILD.bazel
   - pkg/planner/core/casetest/enforcempp/enforce_mpp_test.go
-  - pkg/planner/core/casetest/tpch/BUILD.bazel
-  - pkg/planner/core/casetest/tpch/testdata/tpch_suite_in.json
-  - pkg/planner/core/casetest/tpch/testdata/tpch_suite_out.json
-  - pkg/planner/core/casetest/tpch/testdata/tpch_suite_xut.json
-  - pkg/planner/core/casetest/tpch/tpch_test.go
   - pkg/planner/core/find_best_task.go
   - pkg/planner/core/integration_test.go
-  - pkg/planner/util/misc.go
-  - tests/integrationtest/r/planner/core/integration.result
   PR Summary: This is an automated cherry-pick of #65127 What problem does this PR solve? Problem Summary: What changed and how does it work? Because we use RC isolation, so  is true.
 
 ## Notes

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65208-support-using-ordering-property-to-get-better-join-order.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65208-support-using-ordering-property-to-get-better-join-order.md
@@ -30,6 +30,30 @@
   - pkg/sessionctx/variable/session.go
   - pkg/sessionctx/variable/sysvar.go
   PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work?
+- Related PR #67305: pkg/planner: add order-aware logical join reorder rule
+  URL: https://github.com/pingcap/tidb/pull/67305
+  State: open
+  Merged At: not merged
+  Changed Files Count: 16
+  Main Modules: pkg/planner/core, pkg/planner, pkg/session
+  Sample Changed Files:
+  - pkg/planner/core/BUILD.bazel
+  - pkg/planner/core/casetest/rule/BUILD.bazel
+  - pkg/planner/core/casetest/rule/main_test.go
+  - pkg/planner/core/casetest/rule/rule_cdc_join_reorder_test.go
+  - pkg/planner/core/casetest/rule/testdata/order_aware_join_reorder_suite_in.json
+  - pkg/planner/core/casetest/rule/testdata/order_aware_join_reorder_suite_out.json
+  - pkg/planner/core/casetest/rule/testdata/order_aware_join_reorder_suite_xut.json
+  - pkg/planner/core/joinorder/BUILD.bazel
+  - pkg/planner/core/joinorder/join_order.go
+  - pkg/planner/core/joinorder/ordered_leading.go
+  - pkg/planner/core/operator/logicalop/logical_join.go
+  - pkg/planner/core/optimizer.go
+  - pkg/planner/core/rule/logical_rules.go
+  - pkg/planner/core/rule_order_aware_join_reorder.go
+  - pkg/planner/optimize.go
+  - pkg/sessionctx/stmtctx/stmtctx.go
+  PR Summary: What problem does this PR solve? Problem Summary: The order-aware logic for the new CD-C join reorder path should live in a separate logical rule instead of being mixed into the generic join reorder solver. What changed and how does it work? This PR adds a new logical rule that inspects join groups with propagated TopN / ORDER BY columns, reuses the CD-C  logic, and injects an internal  preference when one ordered leaf can preserve the required ordering with compatible equality filters.
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md
@@ -32,6 +32,30 @@
   - tests/integrationtest/r/planner/core/rule_join_reorder.result
   - tests/integrationtest/r/tpch.result
   PR Summary: What problem does this PR solve? Problem Summary: Cost Model v2 underestimates : the cost formula missed probe-side hash cost and could use incorrect join key count, leading to wrong plan preference. What changed and how does it work? Fix cost model v2 for index-join family in :
+- Fix PR #66786: planner: Adjust cost for semijoin and apply | tidb-test=pr/2703
+  URL: https://github.com/pingcap/tidb/pull/66786
+  State: closed
+  Merged At: 2026-03-18T00:50:47Z
+  Changed Files Count: 16
+  Main Modules: pkg/planner/core, pkg/planner, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/cardinality/BUILD.bazel
+  - pkg/planner/cardinality/selectivity_test.go
+  - pkg/planner/core/casetest/cascades/testdata/cascades_suite_out.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+  - pkg/planner/core/casetest/correlated/testdata/correlated_subquery_suite_out.json
+  - pkg/planner/core/casetest/correlated/testdata/correlated_subquery_suite_xut.json
+  - pkg/planner/core/casetest/rule/testdata/outer2inner_out.json
+  - pkg/planner/core/casetest/rule/testdata/outer2inner_xut.json
+  - pkg/planner/core/casetest/tpch/testdata/tpch_suite_out.json
+  - pkg/planner/core/casetest/tpch/testdata/tpch_suite_xut.json
+  - pkg/planner/core/exhaust_physical_plans.go
+  - pkg/planner/core/operator/logicalop/logical_apply.go
+  - pkg/planner/core/plan_cost_ver2.go
+  - tests/integrationtest/r/planner/core/grouped_ranges_order_by.result
+  - tests/integrationtest/r/topn_push_down.result
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work? Changes This PR improves planner cost modeling for semi-join operators (EXISTS/NOT EXISTS subqueries) across IndexJoin and Apply plans, particularly when ordering is involved.
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65818-analyze-cannot-be-cancelled-promptly.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65818-analyze-cannot-be-cancelled-promptly.md
@@ -2,9 +2,10 @@
 
 ## Metadata
 - Issue: https://github.com/pingcap/tidb/issues/65818
-- Status: open
+- Status: closed
 - Type: type/bug
 - Created At: 2026-01-26T11:27:23Z
+- Closed At: 2026-03-18T04:31:31Z
 - Labels: affects-8.5, report/customer, severity/moderate, sig/planner, type/bug
 
 ## Customer-Facing Phenomenon
@@ -13,15 +14,15 @@
 ## Linked PRs
 - Fix PR #65249: executor: fix analyze cannot be killed
   URL: https://github.com/pingcap/tidb/pull/65249
-  State: open
-  Merged At: not merged
-  Changed Files Count: 12
-  Main Modules: pkg/executor, pkg/distsql, pkg/statistics
+  State: closed
+  Merged At: 2026-03-18T04:31:29Z
+  Changed Files Count: 11
+  Main Modules: pkg/executor, pkg/distsql
   Sample Changed Files:
   - pkg/distsql/distsql.go
   - pkg/executor/analyze.go
   - pkg/executor/analyze_col.go
-  - pkg/executor/analyze_col_v2.go
+  - pkg/executor/analyze_col_sampling.go
   - pkg/executor/analyze_idx.go
   - pkg/executor/analyze_test.go
   - pkg/executor/analyze_utils.go
@@ -29,8 +30,7 @@
   - pkg/executor/test/analyzetest/BUILD.bazel
   - pkg/executor/test/analyzetest/analyze_test.go
   - pkg/executor/test/analyzetest/memorycontrol/memory_control_test.go
-  - pkg/statistics/handle/autoanalyze/autoanalyze.go
-  PR Summary: What problem does this PR solve? Problem Summary: After #63067 removed the coprocessor-side periodic kill polling fallback in , cancellation for  and RPC paths effectively relies on the caller-provided context being canceled promptly. Analyze still had several V1 paths that entered  or RPC with  or otherwise inconsistent contexts. As a result, a kill signal could be observed before entering the RPC, but once a worker was blocked in  or RPC, some paths could not exit proactively. What changed and how does it work?
+  PR Summary: What problem does this PR solve? Problem Summary: After #63067 removed the coprocessor-side periodic kill polling fallback in ,  started depending on the caller-provided context to stop blocked  / DistSQL work promptly. Several analyze paths still used  or did not propagate the same kill-aware context consistently through workers, merge loops, and result handling. As a result, a kill or cancellation could be observed before the RPC started, but some blocked analyze paths still could not exit promptly once they entered  / DistSQL. What changed and how does it work?
 
 ## Notes
-- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md
@@ -22,6 +22,16 @@
   - pkg/planner/cardinality/row_count_index.go
   - pkg/planner/core/integration_test.go
   PR Summary: What problem does this PR solve? Problem Summary: planner: fix a nil pointer bug caused by nil TopN What changed and how does it work? planner: fix a nil pointer bug caused by nil TopN
+- Fix PR #67106: planner: fix a nil pointer bug caused by nil TopN
+  URL: https://github.com/pingcap/tidb/pull/67106
+  State: closed
+  Merged At: 2026-03-18T13:01:15Z
+  Changed Files Count: 2
+  Main Modules: pkg/planner, pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/cardinality/row_count_index.go
+  - pkg/planner/core/integration_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: planner: fix a nil pointer bug caused by nil TopN What changed and how does it work? planner: fix a nil pointer bug caused by nil TopN
 
 ## Notes
 - At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65878-planner-plan-cache-support-queries-with-int-col-str-val.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65878-planner-plan-cache-support-queries-with-int-col-str-val.md
@@ -13,7 +13,7 @@
 ## Linked PRs
 - Fix PR #66198: expression: skip refineArgs for comparisons when plan cache is active
   URL: https://github.com/pingcap/tidb/pull/66198
-  State: open
+  State: closed
   Merged At: not merged
   Changed Files Count: 2
   Main Modules: pkg/expression, pkg/planner/core

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65924-the-estrows-of-equal-condition-is-overestimated-when-the-modify-count-is-zero.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65924-the-estrows-of-equal-condition-is-overestimated-when-the-modify-count-is-zero.md
@@ -15,8 +15,8 @@
   URL: https://github.com/pingcap/tidb/pull/66145
   State: open
   Merged At: not merged
-  Changed Files Count: 21
-  Main Modules: pkg/planner/core, tests/integrationtest, pkg/planner, pkg/statistics, pkg/executor
+  Changed Files Count: 20
+  Main Modules: pkg/planner/core, pkg/planner, tests/integrationtest, pkg/statistics, pkg/executor
   Sample Changed Files:
   - pkg/executor/test/analyzetest/analyze_test.go
   - pkg/planner/cardinality/row_count_column.go
@@ -35,9 +35,9 @@
   - pkg/statistics/histogram.go
   - tests/integrationtest/r/executor/issues.result
   - tests/integrationtest/r/executor/partition/partition_with_expression.result
-  - tests/integrationtest/r/explain_generate_column_substitute.result
   - tests/integrationtest/r/imdbload.result
   - tests/integrationtest/r/planner/core/cbo.result
+  - tests/integrationtest/r/planner/core/integration_partition.result
   PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work? While this affects 8.5 - it will be very difficult to cherry pick. The goal here is to consolidate all "out-of-range" estimation to use the same logic. It shouldn't matter if you are out-of-range for an equals or a range predicate. This is only targeting stats V2 use.
 - Fix PR #66310: planner: out of Range full NDV
   URL: https://github.com/pingcap/tidb/pull/66310

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65938-can-t-find-column-column-6-in-schema-column-column-5-pkoruk-nullableuk.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65938-can-t-find-column-column-6-in-schema-column-column-5-pkoruk-nullableuk.md
@@ -1,0 +1,37 @@
+# Issue #65938: Can't find column Column#6 in schema Column: [Column#5] PKOrUK: [] NullableUK:
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/65938
+- Status: closed
+- Type: type/bug
+- Created At: 2026-01-31T09:46:53Z
+- Closed At: 2026-03-27T11:44:19Z
+- Labels: contribution, report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- 1. Minimal reproduce step (Required)
+
+## Linked PRs
+- Related PR #67359: planner: fix projection pushdown for double-read index lookup
+  URL: https://github.com/pingcap/tidb/pull/67359
+  State: closed
+  Merged At: 2026-03-27T11:44:18Z
+  Changed Files Count: 2
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/issuetest/planner_issue_test.go
+  - pkg/planner/core/task.go
+  PR Summary: What problem does this PR solve? Problem Summary: A query can fail during planning with  when an unfinished double-read path pushes a projection to the index side even though the projection expression still needs table columns. What changed and how does it work? Check whether projection expressions are fully covered by the unfinished index plan before pushing the projection into a cop task.
+- Fix PR #67405: planner: fix projection pushdown for double-read index lookup (#67359)
+  URL: https://github.com/pingcap/tidb/pull/67405
+  State: closed
+  Merged At: 2026-03-30T04:01:18Z
+  Changed Files Count: 2
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/issuetest/planner_issue_test.go
+  - pkg/planner/core/task.go
+  PR Summary: What problem does this PR solve? Problem Summary: For double-read index lookup plans, projection pushdown could be attached to the unfinished index side even when the projected expressions still needed table columns. That could leave required table columns unavailable for the projection. What changed and how does it work? In , when attaching a physical projection to a , finish the index plan first if the unfinished index side cannot provide all projected columns, then push the projection to the table side.
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66623-planner-same-plans-with-different-in-list-should-have-the-same-plan-digests.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66623-planner-same-plans-with-different-in-list-should-have-the-same-plan-digests.md
@@ -40,8 +40,8 @@
   PR Summary: This is an automated cherry-pick of #66624 What problem does this PR solve? Problem Summary: Queries with the same plan but different IN-list lengths (e.g.,  vs ) produce different plan digests. This causes the Dashboard to show many similar plans and harms usability. What changed and how does it work? See
 - Fix PR #66698: planner: enable tidb_ignore_inlist_plan_digest by default to improve user experience and add more test cases (#66624)
   URL: https://github.com/pingcap/tidb/pull/66698
-  State: open
-  Merged At: not merged
+  State: closed
+  Merged At: 2026-03-16T23:16:50Z
   Changed Files Count: 5
   Main Modules: pkg/planner/core, pkg/session
   Sample Changed Files:

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md
@@ -2,10 +2,11 @@
 
 ## Metadata
 - Issue: https://github.com/pingcap/tidb/issues/66668
-- Status: open
+- Status: closed
 - Type: type/enhancement
 - Created At: 2026-03-04T02:53:02Z
-- Labels: plan-rewrite, report/customer, sig/planner, type/enhancement
+- Closed At: 2026-03-18T07:43:13Z
+- Labels: affects-8.5, plan-rewrite, report/customer, sig/planner, type/enhancement
 
 ## Customer-Facing Phenomenon
 - Enhancement See the example below, we can use IndexMerge for the second plan, but can't for the first plan:
@@ -13,8 +14,8 @@
 ## Linked PRs
 - Fix PR #66670: pkg/planner: allow primary key as IndexMerge partial path for `id=? and (a=? or b=?)`
   URL: https://github.com/pingcap/tidb/pull/66670
-  State: open
-  Merged At: not merged
+  State: closed
+  Merged At: 2026-03-18T07:43:11Z
   Changed Files Count: 3
   Main Modules: tests/integrationtest, pkg/planner/core
   Sample Changed Files:
@@ -22,6 +23,17 @@
   - tests/integrationtest/r/planner/core/indexmerge_path.result
   - tests/integrationtest/t/planner/core/indexmerge_path.test
   PR Summary: What problem does this PR solve? Problem Summary: IndexMerge cannot use the primary key as a partial path for predicates like . For example,  falls back to TableRangeScan instead of IndexMerge, while  works correctly. What changed and how does it work? In , the table path (primary key for clustered tables) was skipped whenever  returned nil. For conditions such as , each DNF branch (, ) is first handled separately, and the top-level  is merged later. Because  alone cannot build a valid range on primary key ,  failed and the table path was always skipped, so it never got the merged filters. **Fix:** Only skip the table path when  (int-handle tables). For common-handle/clustered tables,  holds the primary key index, so we keep the gradual filter collection and allow filters like  to be merge
+- Fix PR #67159: pkg/planner: allow primary key as IndexMerge partial path for `id=? and (a=? or b=?)` (#66670)
+  URL: https://github.com/pingcap/tidb/pull/67159
+  State: closed
+  Merged At: 2026-03-23T09:23:22Z
+  Changed Files Count: 3
+  Main Modules: tests/integrationtest, pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/indexmerge_unfinished_path.go
+  - tests/integrationtest/r/planner/core/indexmerge_path.result
+  - tests/integrationtest/t/planner/core/indexmerge_path.test
+  PR Summary: This is an automated cherry-pick of #66670 What problem does this PR solve? Problem Summary: IndexMerge cannot use the primary key as a partial path for predicates like . For example,  falls back to TableRangeScan instead of IndexMerge, while  works correctly. What changed and how does it work? In , the table path (primary key for clustered tables) was skipped whenever  returned nil. For conditions such as , each DNF branch (, ) is first handled separately, and the top-level  is merged later. Because  alone cannot build a valid range on primary key ,  failed and the table path was always skipped, so it never got the merged filters.
 
 ## Notes
-- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66903-planner-task-nil-pointer.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66903-planner-task-nil-pointer.md
@@ -1,0 +1,30 @@
+# Issue #66903: planner:task nil pointer
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/66903
+- Status: closed
+- Type: type/bug
+- Created At: 2026-03-11T04:11:15Z
+- Closed At: 2026-03-28T02:44:11Z
+- Labels: affects-8.5, report/customer, severity/major, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- 1. Minimal reproduce step (Required)
+
+## Linked PRs
+- Fix PR #67105:  planner: fix TopN heavy-function panic when heavy item is not first
+  URL: https://github.com/pingcap/tidb/pull/67105
+  State: closed
+  Merged At: 2026-03-28T02:44:09Z
+  Changed Files Count: 5
+  Main Modules: pkg/planner/core, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/BUILD.bazel
+  - pkg/planner/core/task.go
+  - pkg/planner/core/task_heavy_function_optimize_test.go
+  - tests/integrationtest/r/planner/core/topn_heavy_function_optimize.result
+  - tests/integrationtest/t/planner/core/topn_heavy_function_optimize.test
+  PR Summary: What problem does this PR solve? Issue #67104  was closed by mistake. I have left a comment there requesting a reopen. This PR directly addresses the reported problem. The old  implementation assumes that the first item is the rewritten heavy-function distance column.
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md
@@ -1,0 +1,72 @@
+# Issue #66919: planner, statistics: use selected partition stats for dynamic pruning
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/66919
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-11T13:06:55Z
+- Labels: component/statistics, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- TiDB currently prefers dynamic partition pruning for partitioned tables. This avoids building static-pruning plans, but it also means the optimizer usually estimates row counts from the partition table stats path instead of the stats of the actually selected partitions.
+
+## Linked PRs
+- Fix PR #66920: planner, statistics: use selected partition stats for dynamic pruning
+  URL: https://github.com/pingcap/tidb/pull/66920
+  State: open
+  Merged At: not merged
+  Changed Files Count: 25
+  Main Modules: pkg/planner/core, pkg/session, pkg/planner
+  Sample Changed Files:
+  - pkg/planner/cardinality/BUILD.bazel
+  - pkg/planner/cardinality/ndv_test.go
+  - pkg/planner/cardinality/pseudo.go
+  - pkg/planner/core/casetest/instanceplancache/others_test.go
+  - pkg/planner/core/casetest/plancache/BUILD.bazel
+  - pkg/planner/core/casetest/plancache/plan_cache_partition_table_test.go
+  - pkg/planner/core/casetest/plancache/plan_cache_partition_test.go
+  - pkg/planner/core/casetest/planstats/BUILD.bazel
+  - pkg/planner/core/casetest/planstats/plan_stats_test.go
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/core/operator/logicalop/logical_datasource.go
+  - pkg/planner/core/plan_cache.go
+  - pkg/planner/core/plan_cache_utils.go
+  - pkg/planner/core/planbuilder.go
+  - pkg/planner/core/rule/collect_column_stats_usage.go
+  - pkg/planner/core/rule/rule_partition_processor.go
+  - pkg/planner/core/stats.go
+  - pkg/planner/core/stats/stats.go
+  - pkg/planner/core/tests/prepare/BUILD.bazel
+  - pkg/planner/core/tests/prepare/prepare_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: TiDB uses dynamic partition pruning by default. In some queries that only touch a subset of partitions, cardinality estimation still falls back to the partition table stats path, which is less accurate than using stats merged from the selected partitions. Reusing such partition-specific pruning information through plan cache is also unsafe. What changed and how does it work? Reuse statically-determined partition pruning results in the dynamic pruning path to collect the selected partition IDs for stats estimation.
+- Related PR #67139: [DNM] planner, statistics: use selected partition stats for dynamic pruning
+  URL: https://github.com/pingcap/tidb/pull/67139
+  State: open
+  Merged At: not merged
+  Changed Files Count: 22
+  Main Modules: pkg/planner/core, pkg/session, pkg/planner
+  Sample Changed Files:
+  - pkg/planner/cardinality/BUILD.bazel
+  - pkg/planner/cardinality/ndv_test.go
+  - pkg/planner/cardinality/pseudo.go
+  - pkg/planner/core/casetest/instanceplancache/others_test.go
+  - pkg/planner/core/casetest/planstats/BUILD.bazel
+  - pkg/planner/core/casetest/planstats/plan_stats_test.go
+  - pkg/planner/core/collect_column_stats_usage.go
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/core/operator/logicalop/logical_datasource.go
+  - pkg/planner/core/plan_cache.go
+  - pkg/planner/core/plan_cache_partition_table_test.go
+  - pkg/planner/core/plan_cache_utils.go
+  - pkg/planner/core/planbuilder.go
+  - pkg/planner/core/rule_partition_processor.go
+  - pkg/planner/core/stats.go
+  - pkg/planner/core/tests/prepare/BUILD.bazel
+  - pkg/planner/core/tests/prepare/prepare_test.go
+  - pkg/sessionctx/stmtctx/stmtctx.go
+  - pkg/sessionctx/variable/session.go
+  - pkg/sessionctx/variable/setvar_affect.go
+  PR Summary: What problem does this PR solve? This is cherry pick of Problem Summary: TiDB uses dynamic partition pruning by default. In some queries that only touch a subset of partitions, cardinality estimation still falls back to the partition table stats path, which is less accurate than using stats merged from the selected partitions. Reusing such partition-specific pruning information through plan cache is also unsafe. What changed and how does it work?
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md
@@ -1,0 +1,29 @@
+# Issue #67108: planner: refine reuse chunk heuristic for large rows under root Limit
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67108
+- Status: closed
+- Type: type/enhancement
+- Created At: 2026-03-18T06:30:37Z
+- Closed At: 2026-03-27T14:24:49Z
+- Labels: affects-8.5, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- This issue came from a customer workload even though the GitHub issue does not carry the `report/customer` label. The planner-side reuse-chunk heuristic was still too conservative for some wide-row queries that were effectively bounded on the TiDB root side, especially under a root `Limit`. TiDB disabled chunk reuse too early for bounded overlong-type plans, which increased per-query allocations, triggered more frequent Go GC, and drove higher CPU usage even when the retained reusable-chunk footprint would still have been small enough to be safe.
+
+## Linked PRs
+- Fix PR #67235: planner: refine reuse chunk gating for overlong types
+  URL: https://github.com/pingcap/tidb/pull/67235
+  State: closed
+  Merged At: 2026-03-27T14:24:48Z
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/physicalplantest/physical_plan_test.go
+  - pkg/planner/core/optimizer.go
+  - pkg/planner/core/optimizer_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: `disableReuseChunkIfNeeded` still disables chunk reuse for some bounded overlong-type queries even when the reusable chunk footprint is small enough to be safe. This causes avoidable allocations, more frequent Go GC, and higher CPU usage. What changed and how does it work? Refine the overlong-type reuse-chunk gate to estimate retained reusable-chunk memory for bounded overlong columns, keep the conservative behavior for unbounded large types, and only take the relaxed path when the row bound and stats are trustworthy.
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.
+- Treat this file as a customer-origin planner case that is intentionally kept in the corpus even though the upstream issue is missing the `report/customer` label.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md
@@ -27,3 +27,4 @@
 ## Notes
 - At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.
 - Treat this file as a customer-origin planner case that is intentionally kept in the corpus even though the upstream issue is missing the `report/customer` label.
+- Investigation clue: check `@@last_sql_use_alloc` during triage. A value of `0` is a useful signal that chunk reuse was disabled for the last statement. In this workload pattern, that can correlate with higher allocation pressure, slower compile paths, more frequent Go GC, and higher CPU usage.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md
@@ -1,0 +1,39 @@
+# Issue #67138: When CTE contains ORDER BY, the subquery error returns NULL
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67138
+- Status: closed
+- Type: type/bug
+- Created At: 2026-03-19T03:37:59Z
+- Closed At: 2026-03-23T15:31:00Z
+- Labels: affects-8.5, affects-9.0, contribution, report/customer, severity/major, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- 2. What did you expect to see? (Required) sql results are the same (should both return test) 3. What did you see instead (Required) not same 4. What is your TiDB version? (Required) v8.5.5
+
+## Linked PRs
+- Fix PR #67231: planner/core: fix wrong results caused by rule_project_eliminate for queries with Apply
+  URL: https://github.com/pingcap/tidb/pull/67231
+  State: closed
+  Merged At: 2026-03-23T15:30:58Z
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/rule/BUILD.bazel
+  - pkg/planner/core/casetest/rule/rule_eliminate_projection_test.go
+  - pkg/planner/core/rule_eliminate_projection.go
+  PR Summary: What problem does this PR solve? Problem Summary: There is a replaceMap in : <col-9, col-6>, which means we should replace all  to . But since  only outputs  and ,[ this piece of code]() prevents the replacement from happening. Because it assumes that all target columns to be replaced must come from the child output schema. This is true in normal cases, but correlated columns do not actually come from the child output schema—they are instead set explicitly during the execution of Apply.
+- Fix PR #67246: planner/core: fix wrong results caused by rule_project_eliminate for queries with Apply (#67231)
+  URL: https://github.com/pingcap/tidb/pull/67246
+  State: closed
+  Merged At: 2026-03-24T10:42:58Z
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/rule/BUILD.bazel
+  - pkg/planner/core/casetest/rule/rule_eliminate_projection_test.go
+  - pkg/planner/core/rule_eliminate_projection.go
+  PR Summary: This is an automated cherry-pick of #67231 What problem does this PR solve? Problem Summary: There is a replaceMap in : <col-9, col-6>, which means we should replace all  to . But since  only outputs  and ,[ this piece of code]() prevents the replacement from happening.
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67363-planner-better-binding-matching-mechanism.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67363-planner-better-binding-matching-mechanism.md
@@ -1,0 +1,17 @@
+# Issue #67363: planner: better binding matching mechanism
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67363
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-27T08:27:00Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- See the example below, the second query can't hit the binding because is wrapped by , so it has a different SQL digest. It's better to loose the matching mechanism and allow the second query to hit the binding as well:
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md
@@ -1,0 +1,61 @@
+# Issue #67366: planner: output a warning if implicit join key type conversion happend
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67366
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-27T08:35:34Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Enhancement See the example below, MySQL outputs some warnings to notify the user of the implicit type conversion on , but TiDB doesn't have such warnings:
+
+## Linked PRs
+- Fix PR #67372: planner: warn on implicit join-key type/collation conversion | tidb-test=pr/2718
+  URL: https://github.com/pingcap/tidb/pull/67372
+  State: open
+  Merged At: not merged
+  Changed Files Count: 2
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/join/join_test.go
+  - pkg/planner/core/operator/logicalop/logical_join.go
+  PR Summary: What problem does this PR solve? Problem Summary: planner: warn on implicit join-key type/collation conversion What changed and how does it work? TiDB may implicitly cast join keys with different types/collations (for example ), which can make indexes unusable without visible warning. Add planner warning when join key normalization detects implicit cast-based conversion on join keys.
+- Fix PR #67433: planner: Implicit cast index join | tidb-test=pr/2721
+  URL: https://github.com/pingcap/tidb/pull/67433
+  State: open
+  Merged At: not merged
+  Changed Files Count: 12
+  Main Modules: pkg/planner/core, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
+  - pkg/planner/core/casetest/dag/testdata/plan_suite_xut.json
+  - pkg/planner/core/casetest/rule/testdata/outer2inner_out.json
+  - pkg/planner/core/casetest/rule/testdata/outer2inner_xut.json
+  - pkg/planner/core/issuetest/planner_issue_test.go
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/core/optimizer.go
+  - pkg/planner/core/rule/BUILD.bazel
+  - pkg/planner/core/rule/logical_rules.go
+  - pkg/planner/core/rule/rule_join_key_type_cast.go
+  - tests/integrationtest/r/planner/core/join_key_type_cast.result
+  - tests/integrationtest/t/planner/core/join_key_type_cast.test
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work?
+- Fix PR #67470: planner: Implicit cast varchar local (WIP)
+  URL: https://github.com/pingcap/tidb/pull/67470
+  State: open
+  Merged At: not merged
+  Changed Files Count: 7
+  Main Modules: pkg/planner/core, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/core/optimizer.go
+  - pkg/planner/core/rule/BUILD.bazel
+  - pkg/planner/core/rule/logical_rules.go
+  - pkg/planner/core/rule/rule_join_key_type_cast.go
+  - tests/integrationtest/r/planner/core/join_key_type_cast.result
+  - tests/integrationtest/t/planner/core/join_key_type_cast.test
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work?
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md
@@ -1,0 +1,17 @@
+# Issue #67385: sql-infra: a user wth SUPER privilege can't execute SHOW CONFIG
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67385
+- Status: open
+- Type: type/bug
+- Created At: 2026-03-28T10:27:44Z
+- Labels: report/customer, severity/moderate, sig/planner, sig/sql-infra, type/bug
+
+## Customer-Facing Phenomenon
+- ERROR 1227 (42000): Access denied; you need (at least one of) the CONFIG privilege(s) for this operation
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67409-planner-white-list-based-plan-cache-strategy.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67409-planner-white-list-based-plan-cache-strategy.md
@@ -1,0 +1,17 @@
+# Issue #67409: planner: white-list based Plan Cache strategy
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67409
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-30T06:27:47Z
+- Labels: epic/plan-cache, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Then, for these scenarios, we can: 1) , 2) then use to identify top highly-frequent queries in this workload, 3) add these highly-frequent queries into the white-list.
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md
@@ -1,0 +1,17 @@
+# Issue #67467: enable semi_join_rewrite in multi alternative implementation
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67467
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-31T12:41:16Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- bad plan In real customer env, the final result is zero(IndexJoin_181 output 0 rows), most of time is spent to compute the outer side of , because will keep all rows from , and is a very large table(almost 3,000,000 rows after the filter of .
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md
@@ -11,7 +11,18 @@
 - bad plan In real customer env, the final result is zero(IndexJoin_181 output 0 rows), most of time is spent to compute the outer side of , because will keep all rows from , and is a very large table(almost 3,000,000 rows after the filter of .
 
 ## Linked PRs
-- No linked PR was found from the issue timeline.
+- Fix PR #67497: pkg/planner: support semi join rewrite as an alternative logical plan
+  URL: https://github.com/pingcap/tidb/pull/67497
+  State: open
+  Merged At: not merged
+  Changed Files Count: 4
+  Main Modules: pkg/planner/core, pkg/planner, pkg/session
+  Sample Changed Files:
+  - pkg/planner/core/casetest/rule/rule_outer_to_semi_join_test.go
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/optimize.go
+  - pkg/sessionctx/stmtctx/stmtctx.go
+  PR Summary: What problem does this PR solve? Problem Summary:   The alternative logical plan framework introduced by #66995 can explore a non-decorrelated path and compare physical costs, but it cannot explore the semi-join rewrite path unless the query explicitly uses  or the session variable  is enabled. That means the optimizer may still miss a cheaper plan shape for  /  subqueries when semi-join rewrite is beneficial but not explicitly requested. What changed and how does it work?
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67468-support-join-reorder-for-semi-join.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67468-support-join-reorder-for-semi-join.md
@@ -1,0 +1,17 @@
+# Issue #67468: support join reorder for semi join
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67468
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-31T12:49:43Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- tidb generate the bad plan because we didn't support reorder semi join for now, we'd better support it. Because using hint is not suitable for all situations.
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md
@@ -1,0 +1,28 @@
+# Issue #67498: planner: preserve IN for varchar-vs-numeric comparisons with a common cmp type
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67498
+- Status: open
+- Type: type/bug
+- Created At: 2026-04-01T13:36:46Z
+- Labels: component/expression, may-affects-8.5, report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- TiDB rewrites the  predicate into a DNF of equality predicates: For long  lists this produces a very large expression tree in the planner, even though every element uses the same comparison type. Warning: even after this planner fix,  is still a non-ideal SQL shape for index usage. The comparison has to follow MySQL's mixed-type semantics and usually cannot use the string index as efficiently as a type-aligned predicate. Users should still align the literal type with the column type whenever possible, for example compare  columns with string literals instead of numeric literals. The root cause is that  is only preserved when the comparison type is exactly the left operand's eval type. In this case the comparison type is consistently , but the left operand is , so TiDB unnecessarily expands it to OR-of-EQ.
+
+## Linked PRs
+- Fix PR #67499: planner: preserve IN for common mixed-type comparisons
+  URL: https://github.com/pingcap/tidb/pull/67499
+  State: open
+  Merged At: not merged
+  Changed Files Count: 4
+  Main Modules: pkg/planner/core, pkg/util, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/casetest/integration_test.go
+  - pkg/planner/core/expression_rewriter.go
+  - pkg/util/ranger/ranger_test.go
+  - tests/integrationtest/r/planner/core/casetest/point_get_plan.result
+  PR Summary: What problem does this PR solve? Problem Summary: For mixed-type predicates such as , TiDB currently expands  into a large DNF of  even when every element shares the same comparison type with the left operand. This is semantically unnecessary and makes generated SQL with long  lists much harder for the planner to process. What changed and how does it work?
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.


### PR DESCRIPTION
## Summary

- refresh the TiDB planner customer issue corpus to the latest GitHub state
- add issue `https://github.com/pingcap/tidb/issues/67498` and record its linked fix PR `https://github.com/pingcap/tidb/pull/67499`
- refresh linked PR metadata for issue `https://github.com/pingcap/tidb/issues/67467` and issue `https://github.com/pingcap/tidb/issues/59652`
- update `AGENTS.md` to require full TiDB issue and PR URLs instead of bare `#12345` references

## Testing

- not run; generated markdown corpus update only
