### PR TITLE
chore: refresh tidb planner issue corpus

### DIFF
--- a/skills/tidb-query-tuning/AGENTS.md
+++ b/skills/tidb-query-tuning/AGENTS.md
@@ -86,6 +86,21 @@ Keep and reuse:
 
 Do not treat every generated issue as a mature tuning rule. Generated files are raw field precedents. Promote them into `references/` only after the pattern is stable and reusable.
 
+## TiDB high CPU investigation workflow
+
+When the customer reports high TiDB CPU usage, use the following workflow before jumping to optimizer conclusions:
+
+0. Treat `clinic-api` as the default entry point. If `clinic-api` is unavailable, require the user to provide the equivalent raw evidence first, including CPU profiles, query history, plans, TopSQL, statement summary, and slow query samples.
+1. Define both the problematic time window and a comparable non-problematic baseline window. The baseline should preferably be from the same time-of-day pattern. Pull many TiDB CPU profiles for both sides, ideally around 50 profiles in total if the incident duration allows it.
+2. Compare the problem-window and baseline CPU profiles to identify which stacks or functions consume materially more time during the incident.
+3. Work backward from the hot stacks and infer what query or plan patterns could produce them. Consider optimizer, executor, compiler, GC, memory tracking, range building, and internal SQL paths instead of assuming all CPU comes from user SQL.
+4. Check TopSQL, statement summary, and slow query records in the same time window. Collect the candidate SQLs and their plans, and include internal SQL in the candidate set.
+5. Build a minimal candidate query set that best explains the observed CPU symptom. Use correlation analysis, principal-component style reduction, or combinational optimization to find the smallest query combination that remains highly correlated with the incident signal.
+6. Compare candidate queries against the observed symptom shape. For example, CPU spikes may correlate better with GC pressure, compiler duration, plan building, or execution hot loops than with raw query count alone. Check correlation, periodicity, and dispersion instead of relying only on top-N totals.
+7. If the candidate set does not explain the symptom with high confidence, go back to step 1, expand the profiling sample set, and repeat the comparison with a better baseline or a narrower incident slice.
+
+Use this workflow to decide whether the next step should be query tuning, plan inspection, stats diagnosis, internal SQL investigation, or a product bug report.
+
 ## Tooling assumptions
 
 - `gh` CLI must be installed and authenticated

--- a/skills/tidb-query-tuning/AGENTS.md
+++ b/skills/tidb-query-tuning/AGENTS.md
@@ -86,21 +86,6 @@ Keep and reuse:
 
 Do not treat every generated issue as a mature tuning rule. Generated files are raw field precedents. Promote them into `references/` only after the pattern is stable and reusable.
 
-## TiDB high CPU investigation workflow
-
-When the customer reports high TiDB CPU usage, use the following workflow before jumping to optimizer conclusions:
-
-0. Treat `clinic-api` as the default entry point. If `clinic-api` is unavailable, require the user to provide the equivalent raw evidence first, including CPU profiles, query history, plans, TopSQL, statement summary, and slow query samples.
-1. Define both the problematic time window and a comparable non-problematic baseline window. The baseline should preferably be from the same time-of-day pattern. Pull many TiDB CPU profiles for both sides, ideally around 50 profiles in total if the incident duration allows it.
-2. Compare the problem-window and baseline CPU profiles to identify which stacks or functions consume materially more time during the incident.
-3. Work backward from the hot stacks and infer what query or plan patterns could produce them. Consider optimizer, executor, compiler, GC, memory tracking, range building, and internal SQL paths instead of assuming all CPU comes from user SQL.
-4. Check TopSQL, statement summary, and slow query records in the same time window. Collect the candidate SQLs and their plans, and include internal SQL in the candidate set.
-5. Build a minimal candidate query set that best explains the observed CPU symptom. Use correlation analysis, principal-component style reduction, or combinational optimization to find the smallest query combination that remains highly correlated with the incident signal.
-6. Compare candidate queries against the observed symptom shape. For example, CPU spikes may correlate better with GC pressure, compiler duration, plan building, or execution hot loops than with raw query count alone. Check correlation, periodicity, and dispersion instead of relying only on top-N totals.
-7. If the candidate set does not explain the symptom with high confidence, go back to step 1, expand the profiling sample set, and repeat the comparison with a better baseline or a narrower incident slice.
-
-Use this workflow to decide whether the next step should be query tuning, plan inspection, stats diagnosis, internal SQL investigation, or a product bug report.
-
 ## Tooling assumptions
 
 - `gh` CLI must be installed and authenticated

--- a/skills/tidb-query-tuning/SKILL.md
+++ b/skills/tidb-query-tuning/SKILL.md
@@ -56,6 +56,21 @@ Use this skill to diagnose and resolve TiDB query performance issues. It follows
    - Confirm `actRows` and execution time improved.
    - If the fix is a hint, document it in a SQL comment so future readers understand why.
 
+## High CPU Workflow
+
+When the customer reports high TiDB CPU usage, use the following workflow before jumping to optimizer conclusions:
+
+0. Treat `clinic-api` as the default entry point. If `clinic-api` is unavailable, require the user to provide the equivalent raw evidence first, including CPU profiles, query history, plans, TopSQL, statement summary, and slow query samples.
+1. Define both the problematic time window and a comparable non-problematic baseline window. The baseline should preferably be from the same time-of-day pattern. Pull many TiDB CPU profiles for both sides, ideally around 50 profiles in total if the incident duration allows it.
+2. Compare the problem-window and baseline CPU profiles to identify which stacks or functions consume materially more time during the incident.
+3. Work backward from the hot stacks and infer what query or plan patterns could produce them. Consider optimizer, executor, compiler, GC, memory tracking, range building, and internal SQL paths instead of assuming all CPU comes from user SQL.
+4. Check TopSQL, statement summary, and slow query records in the same time window. Collect the candidate SQLs and their plans, and include internal SQL in the candidate set.
+5. Build a minimal candidate query set that best explains the observed CPU symptom. Use correlation analysis, principal-component style reduction, or combinational optimization to find the smallest query combination that remains highly correlated with the incident signal.
+6. Compare candidate queries against the observed symptom shape. For example, CPU spikes may correlate better with GC pressure, compiler duration, plan building, or execution hot loops than with raw query count alone. Check correlation, periodicity, and dispersion instead of relying only on top-N totals.
+7. If the candidate set does not explain the symptom with high confidence, go back to step 1, expand the profiling sample set, and repeat the comparison with a better baseline or a narrower incident slice.
+
+Use this workflow to decide whether the next step should be query tuning, plan inspection, stats diagnosis, internal SQL investigation, or a product bug report.
+
 ## High-signal rules
 
 - **Always check stats first.** Most bad plans in TiDB come from stale or missing statistics, not optimizer bugs.

--- a/skills/tidb-query-tuning/SKILL.md
+++ b/skills/tidb-query-tuning/SKILL.md
@@ -67,7 +67,8 @@ When the customer reports high TiDB CPU usage, use the following workflow before
 4. Check TopSQL, statement summary, and slow query records in the same time window. Collect the candidate SQLs and their plans, and include internal SQL in the candidate set.
 5. Build a minimal candidate query set that best explains the observed CPU symptom. Use correlation analysis, principal-component style reduction, or combinational optimization to find the smallest query combination that remains highly correlated with the incident signal.
 6. Compare candidate queries against the observed symptom shape. For example, CPU spikes may correlate better with GC pressure, compiler duration, plan building, or execution hot loops than with raw query count alone. Check correlation, periodicity, and dispersion instead of relying only on top-N totals.
-7. If the candidate set does not explain the symptom with high confidence, go back to step 1, expand the profiling sample set, and repeat the comparison with a better baseline or a narrower incident slice.
+7. Do not treat any candidate as the final conclusion until it is statistically validated and cross-validated across multiple evidence sources. The conclusion must be supported by the incident-vs-baseline profile comparison and must also be consistent with flame graphs, TopSQL, slow query, and statement summary observations.
+8. If the candidate set does not explain the symptom with high confidence, or the evidence sources do not validate each other, go back to step 1, expand the profiling sample set, and repeat the comparison with a better baseline or a narrower incident slice.
 
 Use this workflow to decide whether the next step should be query tuning, plan inspection, stats diagnosis, internal SQL investigation, or a product bug report.
 
@@ -78,6 +79,7 @@ Use this workflow to decide whether the next step should be query tuning, plan i
 - **`EXPLAIN ANALYZE` is the ground truth.** `EXPLAIN` alone shows estimates; `ANALYZE` shows what actually happened.
 - **Search known field cases before inventing a new workaround.** The oncall corpus under `references/optimizer-oncall-experiences-redacted/` is useful for symptom matching, investigation signals, and fix-version lookup.
 - **Search recent GitHub issue precedents when fix lineage matters.** The corpus under `references/tidb-customer-planner-issues/` is useful when you need linked PRs, merge times, and still-open customer gaps.
+- **High CPU conclusions require statistical validation and cross-source confirmation.** Do not stop at a plausible stack or top SQL. Treat the result as final only when the signal is statistically supported and mutually validated by profiles or flame graphs, TopSQL, slow query, and statement summary.
 - **Correlated subqueries:** TiDB decorrelates by default. When the subquery is well-indexed and the outer query is selective, `NO_DECORRELATE()` often wins. See `references/subquery-optimization.md`.
 - **Join strategies matter:** TiDB supports hash join, index join, merge join, and shuffle joins. The right choice depends on table sizes, index availability, and data distribution. See `references/join-strategies.md`.
 - **Join type and probe index are separate checks:** `IndexJoin` and `IndexHashJoin` can still be slow because the optimizer picked the wrong inner probe index. Always inspect the probe-side `access object`, pushed predicates, and whether another existing index better matches join keys and covering needs.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/README.md
@@ -2,39 +2,59 @@
 
 - Repository: `pingcap/tidb`
 - Source Query: `repo:pingcap/tidb is:issue label:"report/customer" label:"sig/planner" created:>=2024-01-01`
-- Total Issues: 188
+- Total Issues: 208
 
 | Issue | Status | Type | Linked PR Count | File |
 | --- | --- | --- | ---: | --- |
+| #67904 | open | type/bug | 0 | [issue-67904-read-only-user-variable-is-corrupted-after-select-explain-when-getvar-stays-in-r.md](./issue-67904-read-only-user-variable-is-corrupted-after-select-explain-when-getvar-stays-in-r.md) |
+| #67854 | open | type/compatibility | 0 | [issue-67854-planner-avoid-materializing-in-select-distinct-subqueries-when-semi-join-is-poss.md](./issue-67854-planner-avoid-materializing-in-select-distinct-subqueries-when-semi-join-is-poss.md) |
+| #67817 | open | type/bug | 1 | [issue-67817-planner-optimizer-range-building-memory-is-not-tracked-for-long-in-lists.md](./issue-67817-planner-optimizer-range-building-memory-is-not-tracked-for-long-in-lists.md) |
+| #67815 | open | type/enhancement | 2 | [issue-67815-optimize-prepared-stmt-build-process.md](./issue-67815-optimize-prepared-stmt-build-process.md) |
+| #67774 | open | type/bug | 1 | [issue-67774-planner-greedy-join-reorder-may-seed-outer-join-groups-from-the-smallest-table-i.md](./issue-67774-planner-greedy-join-reorder-may-seed-outer-join-groups-from-the-smallest-table-i.md) |
+| #67756 | open | type/enhancement | 1 | [issue-67756-planner-reduce-ranger-cpu-and-allocations-for-large-in-list-range-building.md](./issue-67756-planner-reduce-ranger-cpu-and-allocations-for-large-in-list-range-building.md) |
+| #67755 | open | type/enhancement | 0 | [issue-67755-planner-can-t-generate-best-mergejoin-limit-plan-for-multi-col-pk-join.md](./issue-67755-planner-can-t-generate-best-mergejoin-limit-plan-for-multi-col-pk-join.md) |
+| #67746 | open | type/enhancement | 1 | [issue-67746-planner-support-rewriting-common-part-in-sql-as-cte-to-avoid-duplicated-executio.md](./issue-67746-planner-support-rewriting-common-part-in-sql-as-cte-to-avoid-duplicated-executio.md) |
+| #67701 | open | type/enhancement | 2 | [issue-67701-planner-mismatched-integer-and-varchar-value-types-prevent-the-optimizer-from-ch.md](./issue-67701-planner-mismatched-integer-and-varchar-value-types-prevent-the-optimizer-from-ch.md) |
+| #67610 | open | type/enhancement | 1 | [issue-67610-planner-inaccurate-cost-model-for-hashagg-indexjoin-vs-hashagg-hashjoin.md](./issue-67610-planner-inaccurate-cost-model-for-hashagg-indexjoin-vs-hashagg-hashjoin.md) |
+| #67595 | closed | type/bug | 2 | [issue-67595-limit-make-optimizer-under-estimate-the-cost-of-indexfullscan.md](./issue-67595-limit-make-optimizer-under-estimate-the-cost-of-indexfullscan.md) |
+| #67573 | open | type/enhancement | 3 | [issue-67573-planner-indexjoin-large-not-in-list-cause-tikv-cpu-spike.md](./issue-67573-planner-indexjoin-large-not-in-list-cause-tikv-cpu-spike.md) |
+| #67552 | open | type/bug | 1 | [issue-67552-query-failed-with-error-1105-unexpected-missing-column-12.md](./issue-67552-query-failed-with-error-1105-unexpected-missing-column-12.md) |
 | #67498 | open | type/bug | 1 | [issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md](./issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md) |
+| #67493 | closed | type/enhancement | 1 | [issue-67493-planner-add-evict-by-key-capability-to-instance-plan-cache.md](./issue-67493-planner-add-evict-by-key-capability-to-instance-plan-cache.md) |
 | #67468 | open | type/enhancement | 0 | [issue-67468-support-join-reorder-for-semi-join.md](./issue-67468-support-join-reorder-for-semi-join.md) |
 | #67467 | open | type/enhancement | 1 | [issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md](./issue-67467-enable-semi-join-rewrite-in-multi-alternative-implementation.md) |
-| #67409 | open | type/enhancement | 0 | [issue-67409-planner-white-list-based-plan-cache-strategy.md](./issue-67409-planner-white-list-based-plan-cache-strategy.md) |
-| #67385 | open | type/bug | 0 | [issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md](./issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md) |
+| #67440 | open | type/enhancement | 1 | [issue-67440-index-join-probe-should-detect-partition-key-to-do-some-dynamic-pruning.md](./issue-67440-index-join-probe-should-detect-partition-key-to-do-some-dynamic-pruning.md) |
+| #67409 | closed | type/enhancement | 1 | [issue-67409-planner-white-list-based-plan-cache-strategy.md](./issue-67409-planner-white-list-based-plan-cache-strategy.md) |
+| #67385 | closed | type/bug | 0 | [issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md](./issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md) |
 | #67366 | open | type/enhancement | 3 | [issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md](./issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md) |
-| #67363 | open | type/enhancement | 0 | [issue-67363-planner-better-binding-matching-mechanism.md](./issue-67363-planner-better-binding-matching-mechanism.md) |
+| #67363 | open | type/enhancement | 1 | [issue-67363-planner-better-binding-matching-mechanism.md](./issue-67363-planner-better-binding-matching-mechanism.md) |
+| #67279 | open | type/enhancement | 0 | [issue-67279-joinreorder-enhancement-plan.md](./issue-67279-joinreorder-enhancement-plan.md) |
+| #67150 | open | type/unknown | 1 | [issue-67150-store-copr-executor-tidb-store-batch-size-has-no-effect-for-tables-with-non-inte.md](./issue-67150-store-copr-executor-tidb-store-batch-size-has-no-effect-for-tables-with-non-inte.md) |
 | #67138 | closed | type/bug | 2 | [issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md](./issue-67138-when-cte-contains-order-by-the-subquery-error-returns-null.md) |
-| #67108 | closed | type/enhancement | 1 | [issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md](./issue-67108-planner-refine-reuse-chunk-heuristic-for-large-rows-under-root-limit.md) |
 | #66919 | open | type/enhancement | 2 | [issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md](./issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md) |
 | #66903 | closed | type/bug | 1 | [issue-66903-planner-task-nil-pointer.md](./issue-66903-planner-task-nil-pointer.md) |
 | #66668 | closed | type/enhancement | 2 | [issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md](./issue-66668-planner-can-t-use-primary-as-an-index-in-indexmerge-for-predicate-id-and-a-or-b.md) |
 | #66658 | open | type/enhancement | 0 | [issue-66658-planner-decrease-concurrency-batch-size-automatically-for-streaming-plans-with-l.md](./issue-66658-planner-decrease-concurrency-batch-size-automatically-for-streaming-plans-with-l.md) |
+| #66651 | closed | type/bug | 2 | [issue-66651-planner-track-ast-decoupling-for-rebuilding-logical-plans-from-a-shared-ast.md](./issue-66651-planner-track-ast-decoupling-for-rebuilding-logical-plans-from-a-shared-ast.md) |
+| #66644 | closed | type/bug | 2 | [issue-66644-planner-common-handle-doesn-t-recognize-order.md](./issue-66644-planner-common-handle-doesn-t-recognize-order.md) |
 | #66623 | closed | type/bug | 3 | [issue-66623-planner-same-plans-with-different-in-list-should-have-the-same-plan-digests.md](./issue-66623-planner-same-plans-with-different-in-list-should-have-the-same-plan-digests.md) |
+| #66585 | closed | type/bug | 2 | [issue-66585-planner-statistics-plan-cache-is-not-invalidated-after-sync-load-timeout-fallbac.md](./issue-66585-planner-statistics-plan-cache-is-not-invalidated-after-sync-load-timeout-fallbac.md) |
 | #66320 | open | type/bug | 1 | [issue-66320-planner-correlate-a-non-correlated-in-subquery.md](./issue-66320-planner-correlate-a-non-correlated-in-subquery.md) |
 | #66203 | open | type/enhancement | 0 | [issue-66203-planner-decrease-the-default-value-64mb-of-tidb-opt-range-max-size.md](./issue-66203-planner-decrease-the-default-value-64mb-of-tidb-opt-range-max-size.md) |
 | #65938 | closed | type/bug | 2 | [issue-65938-can-t-find-column-column-6-in-schema-column-column-5-pkoruk-nullableuk.md](./issue-65938-can-t-find-column-column-6-in-schema-column-column-5-pkoruk-nullableuk.md) |
 | #65924 | open | type/bug | 2 | [issue-65924-the-estrows-of-equal-condition-is-overestimated-when-the-modify-count-is-zero.md](./issue-65924-the-estrows-of-equal-condition-is-overestimated-when-the-modify-count-is-zero.md) |
-| #65916 | open | type/bug | 0 | [issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md](./issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md) |
+| #65916 | closed | type/bug | 1 | [issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md](./issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md) |
 | #65915 | closed | type/bug | 1 | [issue-65915-analyze-statement-freezes-if-saveanalyzeresulttostorage-meets-error-when-analyze.md](./issue-65915-analyze-statement-freezes-if-saveanalyzeresulttostorage-meets-error-when-analyze.md) |
 | #65878 | open | type/enhancement | 1 | [issue-65878-planner-plan-cache-support-queries-with-int-col-str-val.md](./issue-65878-planner-plan-cache-support-queries-with-int-col-str-val.md) |
 | #65876 | closed | type/enhancement | 1 | [issue-65876-planner-non-prep-plan-cache-support-is-null.md](./issue-65876-planner-non-prep-plan-cache-support-is-null.md) |
-| #65867 | closed | type/bug | 2 | [issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md](./issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md) |
-| #65838 | open | type/bug | 0 | [issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md](./issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md) |
+| #65867 | closed | type/bug | 3 | [issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md](./issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md) |
+| #65838 | open | type/bug | 1 | [issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md](./issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md) |
 | #65822 | open | type/enhancement | 0 | [issue-65822-support-building-indexmerge-path-and-pushing-down-limit-for-in-expression-in-nes.md](./issue-65822-support-building-indexmerge-path-and-pushing-down-limit-for-in-expression-in-nes.md) |
 | #65818 | closed | type/bug | 1 | [issue-65818-analyze-cannot-be-cancelled-promptly.md](./issue-65818-analyze-cannot-be-cancelled-promptly.md) |
-| #65712 | open | type/enhancement | 1 | [issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md](./issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md) |
+| #65712 | open | type/enhancement | 2 | [issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md](./issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md) |
 | #65639 | open | type/bug | 0 | [issue-65639-sql-binding-fails-silently-when-sql-is-too-long-binding-created-but-not-visible-.md](./issue-65639-sql-binding-fails-silently-when-sql-is-too-long-binding-created-but-not-visible-.md) |
 | #65556 | open | type/bug | 2 | [issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md](./issue-65556-cost-model-v2-indexhashjoin-cost-underestimation.md) |
+| #65531 | closed | type/enhancement | 1 | [issue-65531-index-join-probe-index-choosing-can-be-prior-to-more-index-keys-covered-when-two.md](./issue-65531-index-join-probe-index-choosing-can-be-prior-to-more-index-keys-covered-when-two.md) |
 | #65489 | closed | type/bug | 3 | [issue-65489-memory-leak-when-analyze-table-is-the-last-statement-in-a-session.md](./issue-65489-memory-leak-when-analyze-table-is-the-last-statement-in-a-session.md) |
 | #65381 | closed | type/bug | 3 | [issue-65381-planner-the-optimizer-can-t-use-the-latest-tidb-mem-quota-binding-cache-value-to.md](./issue-65381-planner-the-optimizer-can-t-use-the-latest-tidb-mem-quota-binding-cache-value-to.md) |
 | #65208 | open | type/enhancement | 2 | [issue-65208-support-using-ordering-property-to-get-better-join-order.md](./issue-65208-support-using-ordering-property-to-get-better-join-order.md) |
@@ -186,7 +206,7 @@
 | #51379 | open | type/enhancement | 0 | [issue-51379-planner-large-cardinality-estimation-error-for-indexjoin-with-indexlookup-when-j.md](./issue-51379-planner-large-cardinality-estimation-error-for-indexjoin-with-indexlookup-when-j.md) |
 | #51362 | closed | type/bug | 5 | [issue-51362-planner-invalid-agg-mode-on-mpp-plans-with-sub-queries-accessing-partitioning-ta.md](./issue-51362-planner-invalid-agg-mode-on-mpp-plans-with-sub-queries-accessing-partitioning-ta.md) |
 | #51358 | closed | type/bug | 2 | [issue-51358-panic-when-to-disable-lite-init-stats.md](./issue-51358-panic-when-to-disable-lite-init-stats.md) |
-| #51116 | closed | type/unknown | 5 | [issue-51116-planner-the-optimizer-can-t-produce-an-optimal-plan-for-queries-with-sub-queries.md](./issue-51116-planner-the-optimizer-can-t-produce-an-optimal-plan-for-queries-with-sub-queries.md) |
+| #51116 | closed | type/unknown | 6 | [issue-51116-planner-the-optimizer-can-t-produce-an-optimal-plan-for-queries-with-sub-queries.md](./issue-51116-planner-the-optimizer-can-t-produce-an-optimal-plan-for-queries-with-sub-queries.md) |
 | #51098 | open | type/enhancement | 1 | [issue-51098-wrong-estimated-row-count-for-tidb-rowid.md](./issue-51098-wrong-estimated-row-count-for-tidb-rowid.md) |
 | #50507 | closed | type/bug | 2 | [issue-50507-planner-set-var-fix-control-is-incompatible-with-binding.md](./issue-50507-planner-set-var-fix-control-is-incompatible-with-binding.md) |
 | #50080 | open | type/bug | 8 | [issue-50080-row-count-estimation-on-datetime-type-is-over-estimated-when-time-span-across-ye.md](./issue-50080-row-count-estimation-on-datetime-type-is-over-estimated-when-time-span-across-ye.md) |

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-51116-planner-the-optimizer-can-t-produce-an-optimal-plan-for-queries-with-sub-queries.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-51116-planner-the-optimizer-can-t-produce-an-optimal-plan-for-queries-with-sub-queries.md
@@ -76,6 +76,26 @@
   - tests/integrationtest/r/cte.result
   - tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
   PR Summary: This is an automated cherry-pick of #63287 What problem does this PR solve? Problem Summary: What changed and how does it work? Enhancement to add LIMIT 1 to EXISTS correlated subqueries (where NO_DECORRELATE hint exists) if no existing LIMIT applies within the subquery.
+- Related PR #67693: [Do Not Merge/ POC only] planner: support rewrite join to apply rule
+  URL: https://github.com/pingcap/tidb/pull/67693
+  State: closed
+  Merged At: not merged
+  Changed Files Count: 12
+  Main Modules: pkg/parser, pkg/planner/core, tests/integrationtest, pkg/executor, pkg/util
+  Sample Changed Files:
+  - pkg/executor/adapter.go
+  - pkg/parser/hintparser.go
+  - pkg/parser/hintparser.y
+  - pkg/parser/hintparser_test.go
+  - pkg/parser/misc.go
+  - pkg/planner/core/optimizer.go
+  - pkg/planner/core/planbuilder.go
+  - pkg/planner/core/rule/logical_rules.go
+  - pkg/planner/core/rule_join_to_apply.go
+  - pkg/util/hint/hint.go
+  - tests/integrationtest/r/planner/core/casetest/hint/join_to_apply.result
+  - tests/integrationtest/t/planner/core/casetest/hint/join_to_apply.test
+  PR Summary: What problem does this PR solve? Problem Summary: support rewrite join to apply rule What changed and how does it work?
 
 ## Notes
 - At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65208-support-using-ordering-property-to-get-better-join-order.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65208-support-using-ordering-property-to-get-better-join-order.md
@@ -32,12 +32,11 @@
   PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work?
 - Related PR #67305: pkg/planner: add order-aware logical join reorder rule
   URL: https://github.com/pingcap/tidb/pull/67305
-  State: open
-  Merged At: not merged
-  Changed Files Count: 16
+  State: closed
+  Merged At: 2026-04-03T07:16:30Z
+  Changed Files Count: 17
   Main Modules: pkg/planner/core, pkg/planner, pkg/session
   Sample Changed Files:
-  - pkg/planner/core/BUILD.bazel
   - pkg/planner/core/casetest/rule/BUILD.bazel
   - pkg/planner/core/casetest/rule/main_test.go
   - pkg/planner/core/casetest/rule/rule_cdc_join_reorder_test.go
@@ -49,8 +48,10 @@
   - pkg/planner/core/joinorder/ordered_leading.go
   - pkg/planner/core/operator/logicalop/logical_join.go
   - pkg/planner/core/optimizer.go
+  - pkg/planner/core/rule/BUILD.bazel
   - pkg/planner/core/rule/logical_rules.go
-  - pkg/planner/core/rule_order_aware_join_reorder.go
+  - pkg/planner/core/rule/rule_order_aware_join_reorder.go
+  - pkg/planner/core/rule_join_reorder.go
   - pkg/planner/optimize.go
   - pkg/sessionctx/stmtctx/stmtctx.go
   PR Summary: What problem does this PR solve? Problem Summary: The order-aware logic for the new CD-C join reorder path should live in a separate logical rule instead of being mixed into the generic join reorder solver. What changed and how does it work? This PR adds a new logical rule that inspects join groups with propagated TopN / ORDER BY columns, reuses the CD-C  logic, and injects an internal  preference when one ordered leaf can preserve the required ordering with compatible equality filters.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65531-index-join-probe-index-choosing-can-be-prior-to-more-index-keys-covered-when-two.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65531-index-join-probe-index-choosing-can-be-prior-to-more-index-keys-covered-when-two.md
@@ -1,0 +1,44 @@
+# Issue #65531: index join probe index choosing can be prior to more index keys covered when two index is not comparable
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/65531
+- Status: closed
+- Type: type/enhancement
+- Created At: 2026-01-12T08:33:48Z
+- Closed At: 2026-02-25T12:07:28Z
+- Labels: affects-8.5, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Enhancement current plan expected plan
+
+## Linked PRs
+- Related PR #65534: planner: index join probe index used cols ndv shouldn't care about range col & add some consideration when two index ndv are quite close
+  URL: https://github.com/pingcap/tidb/pull/65534
+  State: closed
+  Merged At: 2026-02-25T12:07:27Z
+  Changed Files Count: 19
+  Main Modules: pkg/planner/core, pkg/testkit, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/casetest/cbotest/BUILD.bazel
+  - pkg/planner/core/casetest/cbotest/cbo_test.go
+  - pkg/planner/core/casetest/cbotest/main_test.go
+  - pkg/planner/core/casetest/cbotest/testdata/analyzeSuiteTestIndexEqualUnknownT.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyzeSuiteTestLimitIndexEstimationT.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyzeSuiteTestLowSelIndexGreedySearchT.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyzesSuiteTestIndexReadT.json
+  - pkg/planner/core/casetest/cbotest/testdata/issue59563.json
+  - pkg/planner/core/casetest/cbotest/testdata/issue61792.json
+  - pkg/planner/core/casetest/cbotest/testdata/issue62438.json
+  - pkg/planner/core/casetest/cbotest/testdata/stats.zip
+  - pkg/planner/core/casetest/cbotest/testdata/test.t0da79f8d.json
+  - pkg/planner/core/casetest/cbotest/testdata/test.t19f3e4f1.json
+  - pkg/planner/core/index_join_path.go
+  - pkg/testkit/testkit.go
+  - tests/integrationtest/r/planner/core/casetest/index/index.result
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work? as the issue said, sometimes, the index join probe index choosing is more naive, for example in the issue, index_1 and index_2 are in-comparable, then left the decision to the group NDV comparson when compare the group ndv, for index(EQ, EQ, EQ, EQ, col4, col5), the useIndexCols is 4 and we can compute the first 4 EQ's cols group NDV by max each cols' ndv among them.
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65712-better-plan-for-limit-n-order-by-on-indexmerge-when-not-all-partial-paths-satisf.md
@@ -29,6 +29,22 @@
   - tests/integrationtest/r/planner/core/grouped_ranges_order_by.result
   - tests/integrationtest/t/index_merge.test
   PR Summary: What problem does this PR solve? Problem Summary: For queries like : The  partial path can keep order →  returns The  partial path needs merge sort →  returns
+- Fix PR #67771: planner, executor: support merge sort for IN conditions in IndexMerge partial paths
+  URL: https://github.com/pingcap/tidb/pull/67771
+  State: open
+  Merged At: not merged
+  Changed Files Count: 8
+  Main Modules: pkg/executor, tests/integrationtest, pkg/planner/core
+  Sample Changed Files:
+  - pkg/executor/index_merge_reader.go
+  - pkg/executor/mem_reader.go
+  - pkg/executor/test/indexmergereadtest/index_merge_reader_test.go
+  - pkg/planner/core/find_best_task.go
+  - pkg/planner/core/operator/physicalop/physical_index_scan.go
+  - tests/integrationtest/r/index_merge.result
+  - tests/integrationtest/r/planner/core/casetest/physicalplantest/physical_plan.result
+  - tests/integrationtest/t/index_merge.test
+  PR Summary: What problem does this PR solve? Problem Summary: For queries like , where indexes  and  are available: The  partial path on  can directly satisfy  (). The  partial path on  cannot directly satisfy , because the ranges  and  are individually ordered by  but not globally ordered.
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65838-inl-join-hint-shows-warning-when-tidb-opt-advanced-join-hint-off-but-silently-fa.md
@@ -11,7 +11,18 @@
 - Executed a query with hint on TiDB v8.5.5 with different settings of :
 
 ## Linked PRs
-- No linked PR was found from the issue timeline.
+- Fix PR #67838: planner: preserve index join hint warning after advanced join reorder
+  URL: https://github.com/pingcap/tidb/pull/67838
+  State: open
+  Merged At: not merged
+  Changed Files Count: 4
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/joinorder/join_order.go
+  - pkg/planner/core/joinorder/util.go
+  - pkg/planner/core/physical_plan_test.go
+  - pkg/planner/core/rule_join_reorder.go
+  PR Summary: What problem does this PR solve? Problem Summary: When , a side-specific  hint on a join with semijoin-derived children could silently lose its inapplicable warning even though the final plan still did not honor the original hinted join edge. What changed and how does it work? Preserve both children as atomic endpoints during join-group extraction when advanced join hint sees a side-specific index-join hint, so join reorder does not rebind that hint onto a different join edge.
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65867-tidb-runtime-error-invalid-memory-address-or-nil-pointer-dereference.md
@@ -32,6 +32,16 @@
   - pkg/planner/cardinality/row_count_index.go
   - pkg/planner/core/integration_test.go
   PR Summary: What problem does this PR solve? Problem Summary: planner: fix a nil pointer bug caused by nil TopN What changed and how does it work? planner: fix a nil pointer bug caused by nil TopN
+- Fix PR #67840: planner: fix a nil pointer bug caused by nil TopN
+  URL: https://github.com/pingcap/tidb/pull/67840
+  State: closed
+  Merged At: 2026-04-17T08:27:48Z
+  Changed Files Count: 2
+  Main Modules: pkg/planner, pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/cardinality/row_count_index.go
+  - pkg/planner/core/integration_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: planner: fix a nil pointer bug caused by nil TopN What changed and how does it work? planner: fix a nil pointer bug caused by nil TopN
 
 ## Notes
 - At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-65916-explain-for-connection-fails-with-non-prepared-plan-cache-parameterization.md
@@ -2,16 +2,26 @@
 
 ## Metadata
 - Issue: https://github.com/pingcap/tidb/issues/65916
-- Status: open
+- Status: closed
 - Type: type/bug
 - Created At: 2026-01-29T13:34:26Z
+- Closed At: 2026-04-21T06:24:02Z
 - Labels: affects-8.5, report/customer, severity/moderate, sig/planner, type/bug
 
 ## Customer-Facing Phenomenon
 - ERROR 1815 (HY000): expression eq(test.status, ?) cannot be pushed down
 
 ## Linked PRs
-- No linked PR was found from the issue timeline.
+- Fix PR #67835: executor: skip rebuilding explain-for-connection target plans
+  URL: https://github.com/pingcap/tidb/pull/67835
+  State: closed
+  Merged At: 2026-04-21T06:24:01Z
+  Changed Files Count: 2
+  Main Modules: pkg/executor
+  Sample Changed Files:
+  - pkg/executor/builder.go
+  - pkg/executor/explainfor_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: may fail for a non-prepared plan cache query because the recorded target plan still contains parameterized predicates, but the explain session no longer has the live parameter values needed to rebuild that executor.
 
 ## Notes
-- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66320-planner-correlate-a-non-correlated-in-subquery.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66320-planner-correlate-a-non-correlated-in-subquery.md
@@ -15,10 +15,12 @@
   URL: https://github.com/pingcap/tidb/pull/66206
   State: open
   Merged At: not merged
-  Changed Files Count: 22
-  Main Modules: pkg/planner/core, pkg/session, pkg/bindinfo, pkg/planner
+  Changed Files Count: 20
+  Main Modules: pkg/planner/core, pkg/bindinfo, pkg/planner, pkg/session
   Sample Changed Files:
   - pkg/bindinfo/binding_auto_test.go
+  - pkg/bindinfo/binding_plan_generation.go
+  - pkg/planner/BUILD.bazel
   - pkg/planner/core/BUILD.bazel
   - pkg/planner/core/casetest/rule/BUILD.bazel
   - pkg/planner/core/casetest/rule/main_test.go
@@ -26,19 +28,17 @@
   - pkg/planner/core/casetest/rule/testdata/correlate_suite_in.json
   - pkg/planner/core/casetest/rule/testdata/correlate_suite_out.json
   - pkg/planner/core/casetest/rule/testdata/correlate_suite_xut.json
-  - pkg/planner/core/core_init.go
-  - pkg/planner/core/exhaust_physical_plans.go
   - pkg/planner/core/expression_rewriter.go
-  - pkg/planner/core/find_best_task.go
   - pkg/planner/core/operator/logicalop/logical_join.go
-  - pkg/planner/core/operator/physicalop/base_physical_plan.go
   - pkg/planner/core/optimizer.go
   - pkg/planner/core/optimizer_test.go
+  - pkg/planner/core/plan_clone_utils.go
   - pkg/planner/core/rule/logical_rules.go
   - pkg/planner/core/rule_correlate.go
-  - pkg/planner/util/utilfuncp/func_pointer_misc.go
-  - pkg/sessionctx/vardef/tidb_vars.go
-  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work? Claude code review: Detailed PR Review: Cost-Based Selection Between Join and Apply for Non-Correlated IN Subqueries
+  - pkg/planner/optimize.go
+  - pkg/sessionctx/stmtctx/stmtctx.go
+  - pkg/sessionctx/variable/session.go
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work?
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66585-planner-statistics-plan-cache-is-not-invalidated-after-sync-load-timeout-fallbac.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66585-planner-statistics-plan-cache-is-not-invalidated-after-sync-load-timeout-fallbac.md
@@ -1,0 +1,39 @@
+# Issue #66585: planner, statistics: plan cache is not invalidated after sync-load timeout fallback when stats become fully loaded
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/66585
+- Status: closed
+- Type: type/bug
+- Created At: 2026-02-27T16:08:36Z
+- Closed At: 2026-04-02T10:51:14Z
+- Labels: affects-8.5, component/statistics, report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- The cached plan keeps being reused () after stats become fully loaded in memory, until an operation that bumps stats version (e.g. ) or manual cache flush happens.
+
+## Linked PRs
+- Fix PR #67411: planner, statistics: skip plan cache for sync-load fallback plans
+  URL: https://github.com/pingcap/tidb/pull/67411
+  State: closed
+  Merged At: 2026-04-02T10:51:12Z
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/planstats/BUILD.bazel
+  - pkg/planner/core/casetest/planstats/plan_stats_test.go
+  - pkg/planner/core/rule/rule_collect_plan_stats.go
+  PR Summary: What problem does this PR solve? Problem Summary: When sync-load times out and the optimizer falls back to pseudo/partial stats, TiDB can cache the plan built under that temporary degraded state. Later executions may then keep reusing the fallback-built plan even after the missing stats have been loaded. What changed and how does it work? This PR simplifies the fix by treating sync-load timeout fallback as a non-cacheable planning path.
+- Fix PR #67695: planner, statistics: skip plan cache for sync-load fallback plans (#67411)
+  URL: https://github.com/pingcap/tidb/pull/67695
+  State: open
+  Merged At: not merged
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/planstats/BUILD.bazel
+  - pkg/planner/core/casetest/planstats/plan_stats_test.go
+  - pkg/planner/core/rule_collect_plan_stats.go
+  PR Summary: This is an automated cherry-pick of #67411 What problem does this PR solve? Problem Summary: When sync-load times out and the optimizer falls back to pseudo/partial stats, TiDB can cache the plan built under that temporary degraded state. Later executions may then keep reusing the fallback-built plan even after the missing stats have been loaded. What changed and how does it work?
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66644-planner-common-handle-doesn-t-recognize-order.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66644-planner-common-handle-doesn-t-recognize-order.md
@@ -1,0 +1,39 @@
+# Issue #66644: planner: common handle doesn't recognize order
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/66644
+- Status: closed
+- Type: type/bug
+- Created At: 2026-03-03T00:40:40Z
+- Closed At: 2026-03-05T20:45:28Z
+- Labels: affects-8.5, report/customer, severity/minor, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- Given two simple table examples - first with an int PK, and the 2nd with a column handle PK. The int PK (t1) can recognize the ordering of the PK, but the common handle (t2) does not).
+
+## Linked PRs
+- Fix PR #66645: planner: recognize order on common handle PK
+  URL: https://github.com/pingcap/tidb/pull/66645
+  State: closed
+  Merged At: 2026-03-05T20:45:27Z
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/rule/BUILD.bazel
+  - pkg/planner/core/casetest/rule/rule_common_handle_ordering_test.go
+  - pkg/planner/core/find_best_task.go
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work? As exposed by the issue - common handle PKs were not recognized as providing order after the index columns. Integer PKs did recognize order. This PR adds that support. Previously it was 7 lines missing coverage, and now it is 8. But when it was 7 - here is claude code's response:
+- Fix PR #67107: planner: recognize order on common handle PK (#66645)
+  URL: https://github.com/pingcap/tidb/pull/67107
+  State: open
+  Merged At: not merged
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/rule/BUILD.bazel
+  - pkg/planner/core/casetest/rule/rule_common_handle_ordering_test.go
+  - pkg/planner/core/find_best_task.go
+  PR Summary: This is an automated cherry-pick of #66645 What problem does this PR solve? Problem Summary: What changed and how does it work? As exposed by the issue - common handle PKs were not recognized as providing order after the index columns. Integer PKs did recognize order. This PR adds that support.
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66651-planner-track-ast-decoupling-for-rebuilding-logical-plans-from-a-shared-ast.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66651-planner-track-ast-decoupling-for-rebuilding-logical-plans-from-a-shared-ast.md
@@ -1,0 +1,43 @@
+# Issue #66651: planner: track AST decoupling for rebuilding logical plans from a shared AST
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/66651
+- Status: closed
+- Type: type/bug
+- Created At: 2026-03-03T07:22:52Z
+- Closed At: 2026-03-03T11:59:52Z
+- Labels: component/expression, may-affects-8.5, report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- Several planner paths pass AST-owned  objects directly into expression builders. Some of those builders keep the pointer as , and some code paths may even modify the target type during build.
+
+## Linked PRs
+- Fix PR #66652: planner: deep copy AST-owned FieldTypes when building expressions
+  URL: https://github.com/pingcap/tidb/pull/66652
+  State: closed
+  Merged At: 2026-03-03T11:59:51Z
+  Changed Files Count: 9
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/BUILD.bazel
+  - pkg/planner/core/expression_rewriter.go
+  - pkg/planner/core/expression_test.go
+  - pkg/planner/core/operator/logicalop/logical_datasource.go
+  - pkg/planner/core/operator/logicalop/logical_lock.go
+  - pkg/planner/core/operator/logicalop/logical_show.go
+  - pkg/planner/core/operator/physicalop/physical_lock.go
+  - pkg/planner/core/planbuilder.go
+  - pkg/planner/core/planbuilder_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: This PR implements step 1 of issue #66651. It also records the step 2 examination result for the remaining planner-held AST references. When the planner rebuilds logical plans directly from a shared AST, some planner paths still reuse AST-owned mutable  objects. That can make different builds share return-type state through expressions or planner-created constants. What changed and how does it work?
+- Fix PR #66743: pkg/planner: build multiple logical plans from shared AST in optimize
+  URL: https://github.com/pingcap/tidb/pull/66743
+  State: closed
+  Merged At: 2026-03-12T02:55:50Z
+  Changed Files Count: 1
+  Main Modules: pkg/planner
+  Sample Changed Files:
+  - pkg/planner/optimize.go
+  PR Summary: What problem does this PR solve? Problem Summary: This PR implements step 2 of #66651. Step 1 has already been merged; this step adds the actual multi-build flow in  for rebuilding logical plans from a shared AST. What changed and how does it work?
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-66919-planner-statistics-use-selected-partition-stats-for-dynamic-pruning.md
@@ -41,7 +41,7 @@
   PR Summary: What problem does this PR solve? Problem Summary: TiDB uses dynamic partition pruning by default. In some queries that only touch a subset of partitions, cardinality estimation still falls back to the partition table stats path, which is less accurate than using stats merged from the selected partitions. Reusing such partition-specific pruning information through plan cache is also unsafe. What changed and how does it work? Reuse statically-determined partition pruning results in the dynamic pruning path to collect the selected partition IDs for stats estimation.
 - Related PR #67139: [DNM] planner, statistics: use selected partition stats for dynamic pruning
   URL: https://github.com/pingcap/tidb/pull/67139
-  State: open
+  State: closed
   Merged At: not merged
   Changed Files Count: 22
   Main Modules: pkg/planner/core, pkg/session, pkg/planner

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67150-store-copr-executor-tidb-store-batch-size-has-no-effect-for-tables-with-non-inte.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67150-store-copr-executor-tidb-store-batch-size-has-no-effect-for-tables-with-non-inte.md
@@ -1,0 +1,28 @@
+# Issue #67150: store/copr, executor: tidb_store_batch_size has no effect for tables with non-integer clustered primary key
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67150
+- Status: open
+- Type: type/unknown
+- Created At: 2026-03-19T09:30:11Z
+- Labels: contribution, report/customer, sig/execution, sig/planner
+
+## Customer-Facing Phenomenon
+- silently has no effect for tables whose primary key is a non-integer clustered index (e.g. , composite PK). The batching optimization only activates for single-integer PK tables.
+
+## Linked PRs
+- Fix PR #67260: executor: enable tidb_store_batch_size for non-integer clustered PK tables
+  URL: https://github.com/pingcap/tidb/pull/67260
+  State: open
+  Merged At: not merged
+  Changed Files Count: 4
+  Main Modules: pkg/executor, tests/integrationtest
+  Sample Changed Files:
+  - pkg/executor/builder.go
+  - pkg/executor/executor_pkg_test.go
+  - tests/integrationtest/r/executor/jointest/join.result
+  - tests/integrationtest/t/executor/jointest/join.test
+  PR Summary: What problem does this PR solve? had no effect when performing index joins on tables with a non-integer clustered (common handle) primary key (e.g. , composite PK). The store-batch coprocessor path is gated on , but the  branch in  was calling  which never sets hints. Root cause In , when  is true, KV ranges are built via  (with ) and passed directly to  → . That produces a  with . In :
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67279-joinreorder-enhancement-plan.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67279-joinreorder-enhancement-plan.md
@@ -1,0 +1,17 @@
+# Issue #67279: JoinReorder enhancement plan
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67279
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-25T05:52:48Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Enhancement [x] pre-refactor to help introduce CD-C impl: [x] resolve correctness issue by implementing CD-C detection algorithm: [x] enable CD-C impl by default:
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67363-planner-better-binding-matching-mechanism.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67363-planner-better-binding-matching-mechanism.md
@@ -11,7 +11,22 @@
 - See the example below, the second query can't hit the binding because is wrapped by , so it has a different SQL digest. It's better to loose the matching mechanism and allow the second query to hit the binding as well:
 
 ## Linked PRs
-- No linked PR was found from the issue timeline.
+- Fix PR #67532: planner: normalize redundant WHERE parentheses for binding matching
+  URL: https://github.com/pingcap/tidb/pull/67532
+  State: open
+  Merged At: not merged
+  Changed Files Count: 8
+  Main Modules: pkg/session, pkg/parser, tests/integrationtest, pkg/bindinfo
+  Sample Changed Files:
+  - pkg/bindinfo/binding_operator_test.go
+  - pkg/parser/digester.go
+  - pkg/parser/digester_test.go
+  - pkg/session/BUILD.bazel
+  - pkg/session/bootstrap_test.go
+  - pkg/session/upgrade_def.go
+  - tests/integrationtest/r/planner/core/physical_plan.result
+  - tests/integrationtest/r/planner/core/rule_join_reorder.result
+  PR Summary: What problem does this PR solve? Problem Summary: planner: normalize redundant WHERE parentheses for binding matching What changed and how does it work? Strip redundant outer wrappers in  conditions during binding digest normalization. Example:  ->
 
 ## Notes
 - This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67366-planner-output-a-warning-if-implicit-join-key-type-conversion-happend.md
@@ -13,8 +13,8 @@
 ## Linked PRs
 - Fix PR #67372: planner: warn on implicit join-key type/collation conversion | tidb-test=pr/2718
   URL: https://github.com/pingcap/tidb/pull/67372
-  State: open
-  Merged At: not merged
+  State: closed
+  Merged At: 2026-04-03T16:25:02Z
   Changed Files Count: 2
   Main Modules: pkg/planner/core
   Sample Changed Files:
@@ -23,13 +23,14 @@
   PR Summary: What problem does this PR solve? Problem Summary: planner: warn on implicit join-key type/collation conversion What changed and how does it work? TiDB may implicitly cast join keys with different types/collations (for example ), which can make indexes unusable without visible warning. Add planner warning when join key normalization detects implicit cast-based conversion on join keys.
 - Fix PR #67433: planner: Implicit cast index join | tidb-test=pr/2721
   URL: https://github.com/pingcap/tidb/pull/67433
-  State: open
-  Merged At: not merged
-  Changed Files Count: 12
+  State: closed
+  Merged At: 2026-04-07T23:46:42Z
+  Changed Files Count: 13
   Main Modules: pkg/planner/core, tests/integrationtest
   Sample Changed Files:
   - pkg/planner/core/casetest/dag/testdata/plan_suite_out.json
   - pkg/planner/core/casetest/dag/testdata/plan_suite_xut.json
+  - pkg/planner/core/casetest/join/join_test.go
   - pkg/planner/core/casetest/rule/testdata/outer2inner_out.json
   - pkg/planner/core/casetest/rule/testdata/outer2inner_xut.json
   - pkg/planner/core/issuetest/planner_issue_test.go
@@ -45,13 +46,10 @@
   URL: https://github.com/pingcap/tidb/pull/67470
   State: open
   Merged At: not merged
-  Changed Files Count: 7
+  Changed Files Count: 4
   Main Modules: pkg/planner/core, tests/integrationtest
   Sample Changed Files:
   - pkg/planner/core/logical_plan_builder.go
-  - pkg/planner/core/optimizer.go
-  - pkg/planner/core/rule/BUILD.bazel
-  - pkg/planner/core/rule/logical_rules.go
   - pkg/planner/core/rule/rule_join_key_type_cast.go
   - tests/integrationtest/r/planner/core/join_key_type_cast.result
   - tests/integrationtest/t/planner/core/join_key_type_cast.test

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67385-sql-infra-a-user-wth-super-privilege-can-t-execute-show-config.md
@@ -2,9 +2,10 @@
 
 ## Metadata
 - Issue: https://github.com/pingcap/tidb/issues/67385
-- Status: open
+- Status: closed
 - Type: type/bug
 - Created At: 2026-03-28T10:27:44Z
+- Closed At: 2026-04-02T09:34:56Z
 - Labels: report/customer, severity/moderate, sig/planner, sig/sql-infra, type/bug
 
 ## Customer-Facing Phenomenon
@@ -14,4 +15,4 @@
 - No linked PR was found from the issue timeline.
 
 ## Notes
-- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.
+- The issue is closed, but no merged PR was resolved automatically from the timeline. It may have been fixed by an internal branch, a batch PR, or manual closure.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67409-planner-white-list-based-plan-cache-strategy.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67409-planner-white-list-based-plan-cache-strategy.md
@@ -2,16 +2,35 @@
 
 ## Metadata
 - Issue: https://github.com/pingcap/tidb/issues/67409
-- Status: open
+- Status: closed
 - Type: type/enhancement
 - Created At: 2026-03-30T06:27:47Z
+- Closed At: 2026-04-08T21:36:11Z
 - Labels: epic/plan-cache, report/customer, sig/planner, type/enhancement
 
 ## Customer-Facing Phenomenon
-- Then, for these scenarios, we can: 1) , 2) then use to identify top highly-frequent queries in this workload, 3) add these highly-frequent queries into the white-list.
+- Then, for these scenarios, we can: 1) / , 2) then use to identify top highly-frequent queries in this workload, 3) add these highly-frequent queries into the white-list.
 
 ## Linked PRs
-- No linked PR was found from the issue timeline.
+- Fix PR #67535: planner: support use_plan_cache hint and binding under hint_only plan cache strategy
+  URL: https://github.com/pingcap/tidb/pull/67535
+  State: closed
+  Merged At: 2026-04-08T21:36:10Z
+  Changed Files Count: 11
+  Main Modules: pkg/session, pkg/planner/core, pkg/util, tests/integrationtest, pkg/parser, pkg/planner
+  Sample Changed Files:
+  - pkg/parser/ast/misc.go
+  - pkg/planner/core/plan_cache.go
+  - pkg/planner/core/plan_cache_utils.go
+  - pkg/planner/optimize.go
+  - pkg/sessionctx/vardef/tidb_vars.go
+  - pkg/sessionctx/variable/session.go
+  - pkg/sessionctx/variable/sysvar.go
+  - pkg/util/hint/hint.go
+  - pkg/util/hint/hint_processor.go
+  - tests/integrationtest/r/planner/core/plan_cache.result
+  - tests/integrationtest/t/planner/core/plan_cache.test
+  PR Summary: What problem does this PR solve? Problem Summary: planner: support use_plan_cache hint and binding under hint_only plan cache strategy What changed and how does it work? Added new system variable : (default): keep current behavior
 
 ## Notes
-- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67440-index-join-probe-should-detect-partition-key-to-do-some-dynamic-pruning.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67440-index-join-probe-should-detect-partition-key-to-do-some-dynamic-pruning.md
@@ -1,0 +1,30 @@
+# Issue #67440: index join probe should detect partition key to do some dynamic pruning
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67440
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-03-31T02:11:05Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- bg: t2 is a partition table with 600 partition t2's partition key is DAY(t2.c4) t2.idx_b is a local index
+
+## Linked PRs
+- Fix PR #67549: planner: derive static probe pruning conds for index join
+  URL: https://github.com/pingcap/tidb/pull/67549
+  State: open
+  Merged At: not merged
+  Changed Files Count: 6
+  Main Modules: pkg/planner/core, pkg/planner
+  Sample Changed Files:
+  - pkg/planner/core/BUILD.bazel
+  - pkg/planner/core/casetest/partition/BUILD.bazel
+  - pkg/planner/core/casetest/partition/partition_pruner_test.go
+  - pkg/planner/core/exhaust_physical_plans.go
+  - pkg/planner/core/index_join_partition_pruning.go
+  - pkg/planner/property/physical_property.go
+  PR Summary: What problem does this PR solve? Problem Summary: For index join over a partitioned probe-side table, the planner only used the probe table's existing pruning conditions. When the join predicates implied a coarse static range on the probe partition key, the probe-side scan could still keep . What changed and how does it work? This change derives coarse static probe-side partition pruning conditions during index join planning and threads them into the probe scan task's partition pruning info.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67493-planner-add-evict-by-key-capability-to-instance-plan-cache.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67493-planner-add-evict-by-key-capability-to-instance-plan-cache.md
@@ -1,0 +1,28 @@
+# Issue #67493: planner: add evict-by-key capability to instance plan cache
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67493
+- Status: closed
+- Type: type/enhancement
+- Created At: 2026-04-01T09:21:27Z
+- Closed At: 2026-04-01T11:13:15Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- The current instance-level plan cache only exposes , , , and in .
+
+## Linked PRs
+- Fix PR #67495: pkg/planner, pkg/sessionctx: add delete-by-key support for instance plan cache
+  URL: https://github.com/pingcap/tidb/pull/67495
+  State: closed
+  Merged At: not merged
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core, pkg/session
+  Sample Changed Files:
+  - pkg/planner/core/plan_cache_instance.go
+  - pkg/planner/core/plan_cache_instance_test.go
+  - pkg/sessionctx/context.go
+  PR Summary: What problem does this PR solve? Problem Summary: The instance plan cache only exposed , , , and , so callers had no exact-key deletion capability. When an old exact cache key was known, stale instance-cache entries could only be left to logical invalidation or background eviction instead of being reclaimed eagerly. What changed and how does it work? add  to
+
+## Notes
+- The issue is closed, but no merged PR was resolved automatically from the timeline. It may have been fixed by an internal branch, a batch PR, or manual closure.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67498-planner-preserve-in-for-varchar-vs-numeric-comparisons-with-a-common-cmp-type.md
@@ -11,17 +11,22 @@
 - TiDB rewrites the  predicate into a DNF of equality predicates: For long  lists this produces a very large expression tree in the planner, even though every element uses the same comparison type. Warning: even after this planner fix,  is still a non-ideal SQL shape for index usage. The comparison has to follow MySQL's mixed-type semantics and usually cannot use the string index as efficiently as a type-aligned predicate. Users should still align the literal type with the column type whenever possible, for example compare  columns with string literals instead of numeric literals. The root cause is that  is only preserved when the comparison type is exactly the left operand's eval type. In this case the comparison type is consistently , but the left operand is , so TiDB unnecessarily expands it to OR-of-EQ.
 
 ## Linked PRs
-- Fix PR #67499: planner: preserve IN for common mixed-type comparisons
+- Fix PR #67499: planner: preserve IN for common mixed-type comparisons | tidb-test=pr/2723
   URL: https://github.com/pingcap/tidb/pull/67499
   State: open
   Merged At: not merged
-  Changed Files Count: 4
-  Main Modules: pkg/planner/core, pkg/util, tests/integrationtest
+  Changed Files Count: 9
+  Main Modules: tests/integrationtest, pkg/planner/core, pkg/executor, pkg/util
   Sample Changed Files:
+  - pkg/executor/prepared_test.go
   - pkg/planner/core/casetest/integration_test.go
+  - pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
   - pkg/planner/core/expression_rewriter.go
   - pkg/util/ranger/ranger_test.go
+  - tests/integrationtest/r/executor/executor.result
   - tests/integrationtest/r/planner/core/casetest/point_get_plan.result
+  - tests/integrationtest/t/executor/executor.test
+  - tests/integrationtest/t/planner/core/casetest/point_get_plan.test
   PR Summary: What problem does this PR solve? Problem Summary: For mixed-type predicates such as , TiDB currently expands  into a large DNF of  even when every element shares the same comparison type with the left operand. This is semantically unnecessary and makes generated SQL with long  lists much harder for the planner to process. What changed and how does it work?
 
 ## Notes

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67552-query-failed-with-error-1105-unexpected-missing-column-12.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67552-query-failed-with-error-1105-unexpected-missing-column-12.md
@@ -1,0 +1,29 @@
+# Issue #67552: Query failed with ERROR 1105 "Unexpected missing column 12"
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67552
+- Status: open
+- Type: type/bug
+- Created At: 2026-04-03T09:54:14Z
+- Labels: report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- Intermittent failure:
+
+## Linked PRs
+- Fix PR #67692: planner: avoid ambiguous generated column substitution
+  URL: https://github.com/pingcap/tidb/pull/67692
+  State: open
+  Merged At: not merged
+  Changed Files Count: 5
+  Main Modules: pkg/expression, br/pkg, pkg/importsdk, pkg/planner/core
+  Sample Changed Files:
+  - br/pkg/metautil/BUILD.bazel
+  - pkg/expression/column.go
+  - pkg/expression/column_test.go
+  - pkg/importsdk/BUILD.bazel
+  - pkg/planner/core/issuetest/planner_issue_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: When a table has multiple expression indexes backed by different hidden generated columns but sharing the same virtual expression, generated-column substitution may bind predicates to the wrong hidden column. This can produce an invalid IndexLookUp plan and trigger errors such as  on real TiKV. What changed and how does it work? This PR makes generated-column substitution skip ambiguous virtual expressions.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67573-planner-indexjoin-large-not-in-list-cause-tikv-cpu-spike.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67573-planner-indexjoin-large-not-in-list-cause-tikv-cpu-spike.md
@@ -1,0 +1,54 @@
+# Issue #67573: planner: IndexJoin + large not-in list cause TiKV CPU spike
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67573
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-04-06T03:12:26Z
+- Labels: report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Below is the TiKV CPU Profile, a large amount of CPU is spent on decoding requests and building executors, because the not-in list is too large.
+
+## Linked PRs
+- Related PR #67475: planner: simplify grouped max/min having on constant args
+  URL: https://github.com/pingcap/tidb/pull/67475
+  State: closed
+  Merged At: 2026-04-04T10:57:57Z
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core, pkg/resourcegroup
+  Sample Changed Files:
+  - pkg/planner/core/issuetest/planner_issue_test.go
+  - pkg/planner/core/operator/logicalop/logical_aggregation.go
+  - pkg/resourcegroup/tests/BUILD.bazel
+  PR Summary: What problem does this PR solve? Problem Summary: Some generated queries can end up with grouped , for example when a generic aggregation template wraps an expression that no longer depends on input rows after parameterization or simplification. For grouped non-empty results,  of such an expression
+- Fix PR #67574: planner: compress large not-in filters for index join probe
+  URL: https://github.com/pingcap/tidb/pull/67574
+  State: open
+  Merged At: not merged
+  Changed Files Count: 8
+  Main Modules: pkg/planner/core, pkg/resourcegroup
+  Sample Changed Files:
+  - pkg/planner/core/casetest/cbotest/cbo_test.go
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+  - pkg/planner/core/exhaust_physical_plans.go
+  - pkg/planner/core/issuetest/planner_issue_test.go
+  - pkg/planner/core/operator/logicalop/logical_aggregation.go
+  - pkg/resourcegroup/tests/BUILD.bazel
+  PR Summary: What problem does this PR solve? Problem Summary: can amplify the cost of a large  list on the probe side. In the problematic shape from , the join key still uses point lookups on , but the probe-side keeps a very large  expression on another column such as . That
+- Fix PR #67597: planner/core: keep large IN-list probe predicates on root for IndexJoin
+  URL: https://github.com/pingcap/tidb/pull/67597
+  State: closed
+  Merged At: 2026-04-16T19:36:22Z
+  Changed Files Count: 3
+  Main Modules: pkg/planner/core
+  Sample Changed Files:
+  - pkg/planner/core/casetest/join/join_test.go
+  - pkg/planner/core/exhaust_physical_plans.go
+  - pkg/planner/core/find_best_task.go
+  PR Summary: What problem does this PR solve? Problem Summary: pkg/planner/core: keep large IN-list probe predicates on root for IndexJoin What changed and how does it work? Add a fixed guardrail () for IndexJoin probe-side residual predicates. When a probe-side predicate contains a large  list and does not affect access range construction, do not push it to coprocessor; keep it in TiDB root task.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67595-limit-make-optimizer-under-estimate-the-cost-of-indexfullscan.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67595-limit-make-optimizer-under-estimate-the-cost-of-indexfullscan.md
@@ -1,0 +1,45 @@
+# Issue #67595: Limit make optimizer under estimate the cost of IndexFullScan
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67595
+- Status: closed
+- Type: type/bug
+- Created At: 2026-04-07T12:52:57Z
+- Closed At: 2026-04-12T16:56:50Z
+- Labels: affects-8.5, report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- should use IndexJoin and use , instead of  and .   was used instead of  because  the  make optimizer under estimate the cost of  on . On master branch,  is default , so we don't have this problem on masster branch. (And if you set  as -1, this issue can reproduce on master branch again).
+
+## Linked PRs
+- Fix PR #67588: planner: tidb_opt_ordering_index_selectivity_ratio for merge join
+  URL: https://github.com/pingcap/tidb/pull/67588
+  State: closed
+  Merged At: 2026-04-12T16:56:48Z
+  Changed Files Count: 6
+  Main Modules: pkg/planner/core, pkg/planner, pkg/bindinfo
+  Sample Changed Files:
+  - pkg/bindinfo/testdata/binding_auto_suite_out.json
+  - pkg/planner/cardinality/BUILD.bazel
+  - pkg/planner/cardinality/selectivity_test.go
+  - pkg/planner/core/exhaust_physical_plans.go
+  - pkg/planner/core/operator/physicalop/physical_merge_join.go
+  - pkg/planner/core/operator/physicalop/physical_utils.go
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work? Extends the tidb_opt_ordering_index_selectivity_ratio (“ordering penalty”) modeling to MergeJoin by reusing a shared child-ExpectedCnt calculation, and adds a planner/cardinality test intended to validate the new cost behavior. Changes:
+- Fix PR #67906: planner: tidb_opt_ordering_index_selectivity_ratio for merge join (#67588)
+  URL: https://github.com/pingcap/tidb/pull/67906
+  State: open
+  Merged At: not merged
+  Changed Files Count: 6
+  Main Modules: pkg/planner/core, pkg/planner, pkg/bindinfo
+  Sample Changed Files:
+  - pkg/bindinfo/testdata/binding_auto_suite_out.json
+  - pkg/planner/cardinality/BUILD.bazel
+  - pkg/planner/cardinality/selectivity_test.go
+  - pkg/planner/core/exhaust_physical_plans.go
+  - pkg/planner/core/operator/physicalop/physical_merge_join.go
+  - pkg/planner/core/operator/physicalop/physical_utils.go
+  PR Summary: This is an automated cherry-pick of #67588 What problem does this PR solve? Problem Summary: What changed and how does it work? Extends the tidb_opt_ordering_index_selectivity_ratio (“ordering penalty”) modeling to MergeJoin by reusing a shared child-ExpectedCnt calculation, and adds a planner/cardinality test intended to validate the new cost behavior.
+
+## Notes
+- At least one merged PR was found. The merge timestamp above can be used as the fix landing time in the main branch.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67610-planner-inaccurate-cost-model-for-hashagg-indexjoin-vs-hashagg-hashjoin.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67610-planner-inaccurate-cost-model-for-hashagg-indexjoin-vs-hashagg-hashjoin.md
@@ -1,0 +1,35 @@
+# Issue #67610: planner: inaccurate cost model for `HashAgg+IndexJoin` vs `HashAgg+HashJoin`
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67610
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-04-08T08:04:01Z
+- Labels: affects-8.5, epic/cost-model, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Use the script below to reproduce this case, now see the 2 plans below directly: is 2x faster than , but cost is 5x better than the , the cost model is not working well for this case.
+
+## Linked PRs
+- Fix PR #67646: planner/core: discourage degenerate index joins when probe rows approach a full scan
+  URL: https://github.com/pingcap/tidb/pull/67646
+  State: open
+  Merged At: not merged
+  Changed Files Count: 11
+  Main Modules: pkg/planner/core, pkg/session
+  Sample Changed Files:
+  - pkg/planner/core/casetest/cbotest/cbo_test.go
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_in.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_out.json
+  - pkg/planner/core/casetest/cbotest/testdata/analyze_suite_xut.json
+  - pkg/planner/core/casetest/cbotest/testdata/stats.zip
+  - pkg/planner/core/operator/physicalop/physical_utils.go
+  - pkg/planner/core/plan_cost_ver2.go
+  - pkg/planner/core/plan_cost_ver2_test.go
+  - pkg/sessionctx/vardef/tidb_vars.go
+  - pkg/sessionctx/variable/session.go
+  - pkg/sessionctx/variable/sysvar.go
+  PR Summary: What problem does this PR solve? Problem Summary:   When  or  is estimated to probe a large number of inner rows, the optimizer may still prefer it over , even though the index join has already degenerated into a near full-scan pattern and can be slower in practice. What changed and how does it work? This PR introduces a new optimizer sysvar: 
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67701-planner-mismatched-integer-and-varchar-value-types-prevent-the-optimizer-from-ch.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67701-planner-mismatched-integer-and-varchar-value-types-prevent-the-optimizer-from-ch.md
@@ -1,0 +1,42 @@
+# Issue #67701: planner: mismatched integer and varchar value types prevent the optimizer from choosing index range scan
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67701
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-04-11T01:29:42Z
+- Labels: plan-rewrite, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Need to also consider Plan Cache:
+
+## Linked PRs
+- Fix PR #67702: planner: mismatched integer and varchar value types prevent the optimizer from choosing index range scan
+  URL: https://github.com/pingcap/tidb/pull/67702
+  State: closed
+  Merged At: not merged
+  Changed Files Count: 6
+  Main Modules: pkg/util, pkg/planner/core, tests/realtikvtest
+  Sample Changed Files:
+  - pkg/planner/core/casetest/integration_test.go
+  - pkg/planner/core/casetest/plancache/plan_cache_suite_test.go
+  - pkg/util/ranger/checker.go
+  - pkg/util/ranger/detacher.go
+  - pkg/util/ranger/points.go
+  - tests/realtikvtest/addindextest4/BUILD.bazel
+  PR Summary: What problem does this PR solve? Problem Summary: planner: mismatched integer and varchar value types prevent the optimizer from choosing index range scan What changed and how does it work?
+- Related PR #67470: planner: Implicit cast varchar local (WIP)
+  URL: https://github.com/pingcap/tidb/pull/67470
+  State: open
+  Merged At: not merged
+  Changed Files Count: 4
+  Main Modules: pkg/planner/core, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/core/rule/rule_join_key_type_cast.go
+  - tests/integrationtest/r/planner/core/join_key_type_cast.result
+  - tests/integrationtest/t/planner/core/join_key_type_cast.test
+  PR Summary: What problem does this PR solve? Problem Summary: What changed and how does it work?
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67746-planner-support-rewriting-common-part-in-sql-as-cte-to-avoid-duplicated-executio.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67746-planner-support-rewriting-common-part-in-sql-as-cte-to-avoid-duplicated-executio.md
@@ -1,0 +1,36 @@
+# Issue #67746: planner: support rewriting common part in SQL as CTE to avoid duplicated execution
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67746
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-04-14T03:23:32Z
+- Labels: plan-rewrite, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- Below is our Plan, TiDB needs to run the join twice, which could increase resources usage:
+
+## Linked PRs
+- Fix PR #67776: planner/core: add common subplan extract rule
+  URL: https://github.com/pingcap/tidb/pull/67776
+  State: open
+  Merged At: not merged
+  Changed Files Count: 12
+  Main Modules: pkg/planner/core, pkg/session
+  Sample Changed Files:
+  - pkg/planner/core/casetest/rule/main_test.go
+  - pkg/planner/core/casetest/rule/rule_common_subplan_extract_test.go
+  - pkg/planner/core/casetest/rule/testdata/common_subplan_extract_suite_in.json
+  - pkg/planner/core/casetest/rule/testdata/common_subplan_extract_suite_out.json
+  - pkg/planner/core/casetest/rule/testdata/common_subplan_extract_suite_xut.json
+  - pkg/planner/core/logical_plan_builder.go
+  - pkg/planner/core/optimizer.go
+  - pkg/planner/core/rule/logical_rules.go
+  - pkg/planner/core/rule/rule_common_subplan_extract.go
+  - pkg/sessionctx/vardef/tidb_vars.go
+  - pkg/sessionctx/variable/session.go
+  - pkg/sessionctx/variable/sysvar.go
+  PR Summary: What problem does this PR solve? Problem Summary: Real-world analytical queries (TPCH/TPCDS/BI dashboards, view-merged or decorrelated plans) frequently contain structurally identical join subtrees that are planned and executed independently, duplicating scan
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67755-planner-can-t-generate-best-mergejoin-limit-plan-for-multi-col-pk-join.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67755-planner-can-t-generate-best-mergejoin-limit-plan-for-multi-col-pk-join.md
@@ -1,0 +1,17 @@
+# Issue #67755: planner: can't generate best MergeJoin+Limit Plan for multi-col PK join
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67755
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-04-14T07:23:52Z
+- Labels: plan-rewrite, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- But TiDB now can only generate (incur a large sort) or (incur massive double-read requests). The reason why TiDB needs a for is that the primary key is , but the order property is , since the column is missing in the order-clause, TiDB added a sort at the end. But actually, is a fixed value in this SQL , so PK should be able to satisfy the .
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67756-planner-reduce-ranger-cpu-and-allocations-for-large-in-list-range-building.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67756-planner-reduce-ranger-cpu-and-allocations-for-large-in-list-range-building.md
@@ -1,0 +1,30 @@
+# Issue #67756: planner: reduce ranger CPU and allocations for large IN-list range building
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67756
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-04-14T07:41:19Z
+- Labels: component/util, planner/performance, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- still spends substantial CPU time and memory building ranges for large predicates, especially on the long- and cartesian-fanout paths.
+
+## Linked PRs
+- Fix PR #67757: pkg/util/ranger: reduce allocations for large IN-list range building
+  URL: https://github.com/pingcap/tidb/pull/67757
+  State: open
+  Merged At: not merged
+  Changed Files Count: 6
+  Main Modules: pkg/util, docs/agents
+  Sample Changed Files:
+  - docs/agents/notes-guide.md
+  - docs/agents/ranger/README.md
+  - pkg/util/ranger/bench_test.go
+  - pkg/util/ranger/points.go
+  - pkg/util/ranger/ranger.go
+  - pkg/util/ranger/ranger_test.go
+  PR Summary: What problem does this PR solve? Problem Summary: was spending substantial CPU time and memory building ranges for large  predicates. The main pressure came from repeated point/range materialization and per-range small-object allocation on the long- and cartesian-fanout paths. What changed and how does it work? This PR reduces ranger overhead for large  workloads and adds dedicated benchmarks to keep the improvements measurable.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67774-planner-greedy-join-reorder-may-seed-outer-join-groups-from-the-smallest-table-i.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67774-planner-greedy-join-reorder-may-seed-outer-join-groups-from-the-smallest-table-i.md
@@ -1,0 +1,40 @@
+# Issue #67774: planner: greedy join reorder may seed outer-join groups from the smallest table instead of the cheapest first join
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67774
+- Status: open
+- Type: type/bug
+- Created At: 2026-04-15T03:26:07Z
+- Labels: planner/join-order, report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- The greedy algorithm seeds the join group from the smallest base table. In this case it may start from t2, which effectively leads to starting from t1 left join t2, even though that outer join cannot reduce below t1's row count. As a result, the first greedy choice is driven by base-table size instead of the cumulative cost of the first valid join.
+
+## Linked PRs
+- Related PR #67784: planner: add opt-in greedy join reorder start-by-cost switch
+  URL: https://github.com/pingcap/tidb/pull/67784
+  State: open
+  Merged At: not merged
+  Changed Files Count: 16
+  Main Modules: pkg/planner/core, pkg/session, tests/integrationtest
+  Sample Changed Files:
+  - pkg/planner/core/BUILD.bazel
+  - pkg/planner/core/join_reorder_side_effect_test.go
+  - pkg/planner/core/joinorder/BUILD.bazel
+  - pkg/planner/core/joinorder/conflict_detector.go
+  - pkg/planner/core/joinorder/join_order.go
+  - pkg/planner/core/joinorder/join_order_side_effect_test.go
+  - pkg/planner/core/operator/logicalop/logical_projection.go
+  - pkg/planner/core/rule_join_reorder.go
+  - pkg/planner/core/rule_join_reorder_greedy.go
+  - pkg/sessionctx/vardef/tidb_vars.go
+  - pkg/sessionctx/variable/session.go
+  - pkg/sessionctx/variable/setvar_affect.go
+  - pkg/sessionctx/variable/sysvar.go
+  - pkg/sessionctx/variable/varsutil_test.go
+  - tests/integrationtest/r/planner/core/join_reorder2.result
+  - tests/integrationtest/t/planner/core/join_reorder2.test
+  PR Summary: What problem does this PR solve? Problem Summary: Greedy join reorder currently seeds each connected join component from the smallest base relation. That heuristic is not always good enough for outer-join groups. In a query like: when t2 < t3 << t1, the greedy path may start from t2, which effectively picks t1 left join t2 as the first join even though the outer join cannot reduce below t1's row
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67815-optimize-prepared-stmt-build-process.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67815-optimize-prepared-stmt-build-process.md
@@ -1,0 +1,54 @@
+# Issue #67815: Optimize Prepared Stmt build process
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67815
+- Status: open
+- Type: type/enhancement
+- Created At: 2026-04-16T08:25:26Z
+- Labels: affects-8.5, epic/plan-cache, report/customer, sig/planner, type/enhancement
+
+## Customer-Facing Phenomenon
+- For applications that follow the pattern below(i.e., a 1:1 ratio between prepare and execute). As show from the above image, building prepare statement consume almost 17% of CPU usage. We check whether the prepare-statement has been executed before, if yes, we could skip this execution to save some CPU.
+
+## Linked PRs
+- Fix PR #67820: *: support cache prepared statement in plan cache
+  URL: https://github.com/pingcap/tidb/pull/67820
+  State: open
+  Merged At: not merged
+  Changed Files Count: 11
+  Main Modules: pkg/session, tests/integrationtest, pkg/planner/core, pkg/server
+  Sample Changed Files:
+  - pkg/planner/core/plan_cache_utils.go
+  - pkg/server/internal/testserverclient/server_client.go
+  - pkg/session/session.go
+  - pkg/session/test/common/BUILD.bazel
+  - pkg/session/test/common/prepare_dedup_cache_test.go
+  - pkg/sessionctx/vardef/tidb_vars.go
+  - pkg/sessionctx/variable/session.go
+  - pkg/sessionctx/variable/setvar_affect.go
+  - pkg/sessionctx/variable/sysvar.go
+  - tests/integrationtest/r/sessionctx/setvar.result
+  - tests/integrationtest/t/sessionctx/setvar.test
+  PR Summary: What problem does this PR solve? Problem Summary:   CPU profiling showed  consuming ~21% of total CPU in workloads using the prepare-per-request pattern (COM_STMT_PREPARE → COM_STMT_EXECUTE → COM_STMT_CLOSE per request with the same SQL). Each Prepare redundantly executed Parse + Preprocess + PlanBuilder.Build for identical SQL text within the same session. What changed and how does it work?
+- Fix PR #67857: *: support cache prepared statement in plan cache
+  URL: https://github.com/pingcap/tidb/pull/67857
+  State: closed
+  Merged At: 2026-04-18T09:23:03Z
+  Changed Files Count: 11
+  Main Modules: pkg/session, tests/integrationtest, pkg/planner/core, pkg/server
+  Sample Changed Files:
+  - pkg/planner/core/plan_cache_utils.go
+  - pkg/server/internal/testserverclient/server_client.go
+  - pkg/session/session.go
+  - pkg/session/test/common/BUILD.bazel
+  - pkg/session/test/common/prepare_dedup_cache_test.go
+  - pkg/sessionctx/variable/session.go
+  - pkg/sessionctx/variable/setvar_affect.go
+  - pkg/sessionctx/variable/sysvar.go
+  - pkg/sessionctx/variable/tidb_vars.go
+  - tests/integrationtest/r/sessionctx/setvar.result
+  - tests/integrationtest/t/sessionctx/setvar.test
+  PR Summary: What problem does this PR solve? Problem Summary:   CPU profiling showed  consuming ~21% of total CPU in workloads using the prepare-per-request pattern (COM_STMT_PREPARE → COM_STMT_EXECUTE → COM_STMT_CLOSE per request with the same SQL). Each Prepare redundantly executed Parse + Preprocess + PlanBuilder.Build for identical SQL text within the same session. What changed and how does it work?
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67817-planner-optimizer-range-building-memory-is-not-tracked-for-long-in-lists.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67817-planner-optimizer-range-building-memory-is-not-tracked-for-long-in-lists.md
@@ -1,0 +1,36 @@
+# Issue #67817: planner: optimizer range building memory is not tracked for long IN lists
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67817
+- Status: open
+- Type: type/bug
+- Created At: 2026-04-16T08:45:01Z
+- Labels: report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- The memory used during optimizer range-point/range construction is not consistently recorded by the SQL/session . As a result, when a long  list causes high transient memory usage during optimization, OOM alarm/top SQL diagnostics can miss or underreport the SQL responsible.  may prevent some range explosion cases by falling back, but that is separate from memory attribution, and the cached-plan range rebuild path currently bypasses that limit by passing .
+
+## Linked PRs
+- Fix PR #67834: session, ranger: attribute range-build memory to stmt tracker
+  URL: https://github.com/pingcap/tidb/pull/67834
+  State: open
+  Merged At: not merged
+  Changed Files Count: 12
+  Main Modules: pkg/util, pkg/session, pkg/executor, tests/integrationtest
+  Sample Changed Files:
+  - pkg/executor/partition_table_test.go
+  - pkg/session/session.go
+  - pkg/session/test/variable/variable_test.go
+  - pkg/util/ranger/BUILD.bazel
+  - pkg/util/ranger/context/BUILD.bazel
+  - pkg/util/ranger/context/context.go
+  - pkg/util/ranger/context/context_test.go
+  - pkg/util/ranger/memory_test.go
+  - pkg/util/ranger/points.go
+  - pkg/util/ranger/ranger.go
+  - pkg/util/ranger/ranger_test.go
+  - tests/integrationtest/r/executor/executor.result
+  PR Summary: What problem does this PR solve? Problem Summary: Long  lists can allocate a large amount of memory while the optimizer builds ranger points and ranges, but that memory is not attributed to the statement tracker today. On fresh , a focused probe still showed large planner-side allocations for  while  stayed at . What changed and how does it work? Pass  into  from .
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67854-planner-avoid-materializing-in-select-distinct-subqueries-when-semi-join-is-poss.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67854-planner-avoid-materializing-in-select-distinct-subqueries-when-semi-join-is-poss.md
@@ -1,0 +1,17 @@
+# Issue #67854: planner: avoid materializing IN (SELECT DISTINCT ...) subqueries when semi-join is possible
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67854
+- Status: open
+- Type: type/compatibility
+- Created At: 2026-04-17T10:16:29Z
+- Labels: affects-8.5, component/executor, report/customer, sig/planner, type/compatibility, type/performance
+
+## Customer-Facing Phenomenon
+- TiDB materializes/deduplicates the subquery result with aggregation before evaluating the  predicate. In the observed case, the inner table statistics are large enough that this produces a plan with  over a  of the inner table. Observed impact from the production-like case: | Query shape | Plan shape | Observed memory | | --- | --- | --- |
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.

--- a/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67904-read-only-user-variable-is-corrupted-after-select-explain-when-getvar-stays-in-r.md
+++ b/skills/tidb-query-tuning/references/tidb-customer-planner-issues/issue-67904-read-only-user-variable-is-corrupted-after-select-explain-when-getvar-stays-in-r.md
@@ -1,0 +1,17 @@
+# Issue #67904: read-only user variable is corrupted after SELECT/EXPLAIN when getvar() stays in root plan
+
+## Metadata
+- Issue: https://github.com/pingcap/tidb/issues/67904
+- Status: open
+- Type: type/bug
+- Created At: 2026-04-20T02:26:39Z
+- Labels: contribution, report/customer, severity/moderate, sig/planner, type/bug
+
+## Customer-Facing Phenomenon
+- I can reproduce two forms of corruption on the same v8.5.6 playground: 1. Running  mutates  from the UUID to: After that, the following  returns  rows because the variable is already corrupted. 2. If I reset  and run the  directly without the preceding , the query returns the expected 2 matching rows, but  is still corrupted afterwards:
+
+## Linked PRs
+- No linked PR was found from the issue timeline.
+
+## Notes
+- This issue is still open. Use this file as a reminder list for customer-driven gaps that still need a fix or a completed rollout.


### PR DESCRIPTION
## Summary

- refresh `skills/tidb-query-tuning/references/tidb-customer-planner-issues/` with the latest `report/customer` + `sig/planner` issue corpus from `pingcap/tidb`
- update the generated README index from 188 to 208 issues
- add newly matched recent planner issue entries and refresh existing entries with updated issue status, linked PRs, and metadata

## Verification

- regenerated the corpus with:
  - `python3 scripts/generate_tidb_issue_experiences.py --query 'repo:pingcap/tidb is:issue label:"report/customer" label:"sig/planner" created:>=2024-01-01' --out-dir references/tidb-customer-planner-issues`
- spot-checked the regenerated README header and newest issue entries

## Notes

- this is generated knowledge-base content only; no runtime code paths changed
